### PR TITLE
Annotated Worker Improvements

### DIFF
--- a/conductor-client/src/main/java/com/netflix/conductor/client/automator/TaskRunnerConfigurer.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/client/automator/TaskRunnerConfigurer.java
@@ -85,6 +85,10 @@ public class TaskRunnerConfigurer {
         return this.threadCount;
     }
 
+    public int getWorkerCount() {
+        return workers.size();
+    }
+
     /**
      * @return Thread Count for individual task type
      */

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
@@ -170,6 +170,14 @@ public class WorkflowExecutor {
         annotatedWorkerExecutor.initWorkers(packagesToScan);
     }
 
+    public void initWorkersFromInstances(List<Object> workerInstances) {
+        annotatedWorkerExecutor.initWorkersFromInstances(workerInstances);
+    }
+
+    public void initWorkersFromClasses(List<? extends Class<?>> classesToScan) {
+        annotatedWorkerExecutor.initWorkersFromClasses(classesToScan);
+    }
+
     public CompletableFuture<Workflow> executeWorkflow(String name, Integer version, Object input) {
         CompletableFuture<Workflow> future = new CompletableFuture<>();
         String workflowId = startWorkflow(name, version, input);

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
@@ -166,7 +166,7 @@ public class WorkflowExecutor {
                 TimeUnit.MILLISECONDS);
     }
 
-    public void initWorkers(String packagesToScan) {
+    public void initWorkers(String... packagesToScan) {
         annotatedWorkerExecutor.initWorkers(packagesToScan);
     }
 

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
@@ -48,7 +48,7 @@ public class AnnotatedWorkerExecutor {
 
     private MetricsCollector metricsCollector;
 
-    private static final Set<String> scannedPackages = new HashSet<>();
+    private final Set<String> scannedPackages = new HashSet<>();
 
     private final WorkerConfiguration workerConfiguration;
 

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
@@ -21,10 +21,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-import com.netflix.conductor.sdk.workflow.executor.task.workers1.CarWorker1;
-import com.netflix.conductor.sdk.workflow.executor.task.workers1.JumboWorker1;
-import com.netflix.conductor.sdk.workflow.executor.task.workers2.CarWorker2;
-import com.netflix.conductor.sdk.workflow.executor.task.workers2.JumboWorker2;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +28,10 @@ import com.netflix.conductor.client.automator.TaskRunnerConfigurer;
 import com.netflix.conductor.client.http.TaskClient;
 import com.netflix.conductor.client.worker.Worker;
 import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.sdk.workflow.executor.task.workers1.CarWorker1;
+import com.netflix.conductor.sdk.workflow.executor.task.workers1.JumboWorker1;
+import com.netflix.conductor.sdk.workflow.executor.task.workers2.CarWorker2;
+import com.netflix.conductor.sdk.workflow.executor.task.workers2.JumboWorker2;
 import com.netflix.conductor.sdk.workflow.task.InputParam;
 import com.netflix.conductor.sdk.workflow.task.OutputParam;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/Bike.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/Bike.java
@@ -13,13 +13,13 @@
 package com.netflix.conductor.sdk.workflow.executor.task;
 
 public class Bike {
-    String brand;
+    public String brand;
 
-    String getBrand() {
+    public String getBrand() {
         return brand;
     }
 
-    void setBrand(String brand) {
+    public void setBrand(String brand) {
         this.brand = brand;
     }
 }

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers1/CarWorker1.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers1/CarWorker1.java
@@ -10,15 +10,16 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.sdk.workflow.executor.task;
+package com.netflix.conductor.sdk.workflow.executor.task.workers1;
 
 import java.util.List;
 
+import com.netflix.conductor.sdk.workflow.executor.task.Car;
 import com.netflix.conductor.sdk.workflow.task.InputParam;
 import com.netflix.conductor.sdk.workflow.task.OutputParam;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
 
-public class CarWorker {
+public class CarWorker1 {
     @WorkerTask("test_1")
     public @OutputParam("result") List<Car> doWork(@InputParam("input") List<Car> input) {
         return input;

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers1/JumboWorker1.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers1/JumboWorker1.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.netflix.conductor.sdk.workflow.executor.task.workers1;
 
 

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers1/JumboWorker1.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers1/JumboWorker1.java
@@ -1,0 +1,42 @@
+package com.netflix.conductor.sdk.workflow.executor.task.workers1;
+
+
+import com.netflix.conductor.sdk.workflow.task.OutputParam;
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+
+public class JumboWorker1 {
+    @WorkerTask("jumbo_task_1_1")
+    public @OutputParam("result") String task1() {
+        return "dummy data 1";
+    }
+
+    @WorkerTask("jumbo_task_1_2")
+    public @OutputParam("result") String task2() {
+        return "dummy data 2";
+    }
+
+    @WorkerTask("jumbo_task_1_3")
+    public @OutputParam("result") String task3() {
+        return "dummy data 3";
+    }
+
+    @WorkerTask("jumbo_task_1_4")
+    public @OutputParam("result") String task4() {
+        return "dummy data 4";
+    }
+
+    @WorkerTask("jumbo_task_1_5")
+    public @OutputParam("result") String task5() {
+        return "dummy data 5";
+    }
+
+    @WorkerTask("jumbo_task_1_6")
+    public @OutputParam("result") String task6() {
+        return "dummy data 6";
+    }
+
+    @WorkerTask("jumbo_task_1_7")
+    public @OutputParam("result") String task7() {
+        return "dummy data 7";
+    }
+}

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers2/CarWorker2.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers2/CarWorker2.java
@@ -10,16 +10,18 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.sdk.workflow.executor.task;
+package com.netflix.conductor.sdk.workflow.executor.task.workers2;
 
-public class Car {
-    public String brand;
+import com.netflix.conductor.sdk.workflow.executor.task.Car;
+import com.netflix.conductor.sdk.workflow.task.InputParam;
+import com.netflix.conductor.sdk.workflow.task.OutputParam;
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
 
-    public String getBrand() {
-        return brand;
-    }
+import java.util.List;
 
-    public void setBrand(String brand) {
-        this.brand = brand;
+public class CarWorker2 {
+    @WorkerTask("test_2")
+    public @OutputParam("result") List<Car> doWork(@InputParam("input") List<Car> input) {
+        return input;
     }
 }

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers2/CarWorker2.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers2/CarWorker2.java
@@ -12,12 +12,12 @@
  */
 package com.netflix.conductor.sdk.workflow.executor.task.workers2;
 
+import java.util.List;
+
 import com.netflix.conductor.sdk.workflow.executor.task.Car;
 import com.netflix.conductor.sdk.workflow.task.InputParam;
 import com.netflix.conductor.sdk.workflow.task.OutputParam;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
-
-import java.util.List;
 
 public class CarWorker2 {
     @WorkerTask("test_2")

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers2/JumboWorker2.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers2/JumboWorker2.java
@@ -1,0 +1,42 @@
+package com.netflix.conductor.sdk.workflow.executor.task.workers2;
+
+
+import com.netflix.conductor.sdk.workflow.task.OutputParam;
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+
+public class JumboWorker2 {
+    @WorkerTask("jumbo_task_2_1")
+    public @OutputParam("result") String task1() {
+        return "dummy data 1";
+    }
+
+    @WorkerTask("jumbo_task_2_2")
+    public @OutputParam("result") String task2() {
+        return "dummy data 2";
+    }
+
+    @WorkerTask("jumbo_task_2_3")
+    public @OutputParam("result") String task3() {
+        return "dummy data 3";
+    }
+
+    @WorkerTask("jumbo_task_2_4")
+    public @OutputParam("result") String task4() {
+        return "dummy data 4";
+    }
+
+    @WorkerTask("jumbo_task_2_5")
+    public @OutputParam("result") String task5() {
+        return "dummy data 5";
+    }
+
+    @WorkerTask("jumbo_task_2_6")
+    public @OutputParam("result") String task6() {
+        return "dummy data 6";
+    }
+
+    @WorkerTask("jumbo_task_2_7")
+    public @OutputParam("result") String task7() {
+        return "dummy data 7";
+    }
+}

--- a/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers2/JumboWorker2.java
+++ b/java-sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/workers2/JumboWorker2.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.netflix.conductor.sdk.workflow.executor.task.workers2;
 
 

--- a/java-sdk/worker_sdk.md
+++ b/java-sdk/worker_sdk.md
@@ -75,16 +75,42 @@ Output:
 ```
 
 ## Managing Task Workers
-Annotated Workers are managed by [WorkflowExecutor](https://github.com/conductor-oss/conductor/blob/main/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java)
+Annotated Workers are managed by [WorkflowExecutor](https://github.com/conductor-oss/java-sdk/blob/main/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java)
 
 ### Start Workers
+To start workers via classpath scanning, use either of the `initWorkers` methods in the `WorkflowExecutor` class.
 ```java
 WorkflowExecutor executor = new WorkflowExecutor("http://server/api/");
-//List of packages  (comma separated) to scan for annotated workers.  
-// Please note, the worker method MUST be public and the class in which they are defined
-//MUST have a no-args constructor        
+// List of packages  (comma separated) to scan for annotated workers.  
+// Please note, the worker method(s) MUST be public and the class in which they are defined
+// MUST have a no-args constructor        
 executor.initWorkers("com.company.package1,com.company.package2");
+
+// You may also specify packages as separate variadic arguments rather than comma-separated
+executor.initWorkers("com.company.package1", "com.company.package2");
 ```
+
+To start workers via a specific class (or list of classes) use the `initWorkersFromClasses` method. This will not scan
+the entire classpath, but only the classes you specify.
+```java
+WorkflowExecutor executor = new WorkflowExecutor("http://server/api/");
+
+// As above, note that the worker method(s) MUST be public and the class in which they are defined
+// MUST have a no-args constructor
+executor.initWorkersFromClasses(List.of(MyCoolWorker.class, SomeOtherWorker.class));
+```
+
+Finally, if you want to manage your workers in a way that requires you to construct them without no-args constructors,
+you may use the `initWorkersFromInstances` method. This allows you to pass in instances of your worker classes.
+```java
+WorkflowExecutor executor = new WorkflowExecutor("http://server/api/");
+
+// As above, note that the worker method(s) MUST be public
+executor.initWorkersFromInstances(List.of(
+        myCoolWorkerInstance, someOtherWorkerInstance
+))
+```
+
 
 ### Stop Workers
 The code fragment to stop workers at shutdown of the application.


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

This PR has three changes:
- Add additional methods for processing annotated workers that don't rely on classpath scanning
- Allow scanned classpaths to be provided in variadic fashion (in addition to the current comma-separated method)
- Shut down old annotated task runners when starting with additional workers
- Add more tracing mechanisms for better debugging in cases where workers are not scanned