### PR TITLE
Fix S3 presigned URL upload 403 error by setting Content-Type header

### DIFF
--- a/conductor-client/src/main/java/com/netflix/conductor/client/http/PayloadStorage.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/client/http/PayloadStorage.java
@@ -93,6 +93,7 @@ class PayloadStorage implements ExternalPayloadStorage {
             connection = (HttpURLConnection) url.openConnection();
             connection.setDoOutput(true);
             connection.setRequestMethod("PUT");
+            connection.setRequestProperty("Content-Type", "application/json");
 
             try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(connection.getOutputStream())) {
                 byte[] buffer = new byte[BUFFER_SIZE];


### PR DESCRIPTION
## Summary

- Adds `Content-Type: application/json` header when uploading to S3 presigned URLs
- Fixes compatibility with Conductor Server v3.21.17+ which includes content-type in presigned URL signatures

## Context

The server's AWS SDK v2 upgrade (commit `f2ef95cd6` in v3.21.17) now sets `.contentType("application/json")` on `PutObjectRequest` before presigning, resulting in `X-Amz-SignedHeaders=content-type;host`. The client must send a matching header or S3 rejects with 403.

Fixes conductor-oss/conductor#694

## Test plan

- [ ] CI tests pass
- [ ] Manual verification with Conductor Server v3.21.17+ and S3 external payload storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)