### PR TITLE
Add OSV-Scanner workflow for vulnerability scanning

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -1,0 +1,16 @@
+name: OSV-Scanner Scheduled Scan
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+  push:
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan-scheduled:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.3"

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,33 +1,16 @@
-name: OSV-Scanner Vulnerability Scan
+name: OSV-Scanner PR Scan
 
 on:
   pull_request:
     branches: [main]
-  push:
+  merge_group:
     branches: [main]
-  schedule:
-    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
-  workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 
 jobs:
-  osv-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run OSV-Scanner
-        uses: google/osv-scanner-action/osv-scanner-action@v2
-        with:
-          scan-args: |-
-            --recursive
-            ./
-
-      - name: Upload SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
+  scan-pr:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.3"


### PR DESCRIPTION
## Summary
- Add OSV-Scanner GitHub Actions workflow that runs on PR, push to main, weekly schedule, and manual dispatch
- Uploads SARIF results to GitHub Security tab
- Dependabot was already configured for this repo (gradle + github-actions ecosystems)