### PR TITLE
Bump spring-boot-starter from 3.3.0 to 3.3.11

### DIFF
--- a/conductor-client-spring/build.gradle
+++ b/conductor-client-spring/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     api project(":conductor-client")
-    implementation 'org.springframework.boot:spring-boot-starter:3.3.0'
+    implementation 'org.springframework.boot:spring-boot-starter:3.3.11'
 }
 
 java {


### PR DESCRIPTION
## Summary
- Bumps `org.springframework.boot:spring-boot-starter` from 3.3.0 to 3.3.11
- Fixes CVE-2025-22235: `EndpointRequest.to()` creates wrong matcher if actuator endpoint is not exposed

## References
- Closes #84
- [CVE-2025-22235](https://avd.aquasec.com/nvd/cve-2025-22235)