### PR TITLE
fix: helloworld example — remove Orkes auth dependency for OSS users

### DIFF
--- a/examples/old/src/main/java/com/netflix/conductor/sdk/examples/helloworld/Main.java
+++ b/examples/old/src/main/java/com/netflix/conductor/sdk/examples/helloworld/Main.java
@@ -16,15 +16,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import com.netflix.conductor.client.http.ConductorClient;
 import com.netflix.conductor.sdk.examples.helloworld.workflowdef.GreetingsWorkflow;
 import com.netflix.conductor.sdk.workflow.executor.WorkflowExecutor;
-
-import io.orkes.conductor.sdk.examples.util.ClientUtil;
 
 public class Main {
 
     public static void main(String[] args) throws ExecutionException, InterruptedException, TimeoutException {
-        var workflowExecutor = new WorkflowExecutor(ClientUtil.getClient(), 10);
+        String serverUrl = System.getenv().getOrDefault("CONDUCTOR_SERVER_URL", "http://localhost:8080/api");
+        var workflowExecutor = new WorkflowExecutor(new ConductorClient(serverUrl), 10);
         workflowExecutor.initWorkers("com.netflix.conductor.sdk.examples.helloworld.workers");
         var workflowCreator = new GreetingsWorkflow(workflowExecutor);
         var simpleWorkflow = workflowCreator.create();


### PR DESCRIPTION
## Summary

Updates the `helloworld` example to construct `ConductorClient` directly using `CONDUCTOR_SERVER_URL` (default `http://localhost:8080/api`) instead of routing through `ClientUtil` / `ApiClient`. OSS Conductor has no auth keys, so the Orkes-auth-aware `ApiClient` path was unnecessary and caused first-run failures.

## Scope note

This PR originally bundled three fixes (NPE in `ApiClient`, missing `run` task, helloworld auth dependency). Since opening the PR, main has absorbed:

- The NPE fix in `ApiClient.applyEnvVariables()` — now structurally equivalent on main, so **conductor-oss/getting-started#51** can be closed as fixed.
- The `application` plugin for `./gradlew :examples:run`.
- A rewrite of `examples/README.md` as part of the new 791-example structure.

The only remaining change is a 3-line edit to `examples/old/src/main/java/com/netflix/conductor/sdk/examples/helloworld/Main.java` so the helloworld example runs against an OSS server with no auth config.

## User impact

A first-time OSS user running the `helloworld` example no longer needs to set `CONDUCTOR_AUTH_KEY` / `CONDUCTOR_AUTH_SECRET` — the example connects to `http://localhost:8080/api` directly. They can point it elsewhere with `CONDUCTOR_SERVER_URL`.

Fixes conductor-oss/getting-started#51 (helloworld auth portion; NPE portion already resolved on main)