### PR TITLE
docs: clarify OSS vs Orkes-only examples in old/ directory

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1053,4 +1053,4 @@ All examples support `--workers` flag for worker-only mode.
 
 ## Legacy Examples
 
-The original Gradle-based examples are preserved in [old/](old/).
+The original Gradle-based examples are preserved in [old/](old/). See [old/README.md](old/README.md) for which examples are OSS-compatible and which require Orkes Cloud credentials.

--- a/examples/old/README.md
+++ b/examples/old/README.md
@@ -1,268 +1,50 @@
-# Conductor Java SDK Examples
+# Legacy Gradle Examples
 
-118 curated examples demonstrating how to use the Conductor Java SDK for building distributed applications, workflow orchestration, and AI-native workflows. Each example is a standalone Maven project that can be built and run independently.
+These are the original Gradle-based examples, preserved for reference. For new projects, use the [791 Maven examples](../) instead — they are self-contained, easier to run, and all OSS-compatible.
 
-## Quick Start
-
-```bash
-# Start Conductor locally
-docker run -d -p 8080:8080 -p 1234:5000 orkesio/orkes-conductor-standalone:latest
-
-# Run any example
-cd examples/basics/hello-world
-mvn package -DskipTests
-java -jar target/hello-world-1.0.0.jar
-
-# Or use the launcher script
-./run.sh
-
-```
-
-## Examples by Category
-
-### Basics (10 examples)
-
-| Example | Description |
-|---------|-------------|
-| [hello-world](basics/hello-world/) | Minimal workflow with a single worker |
-| [creating-workers](basics/creating-workers/) | How to implement and register workers |
-| [registering-workflows](basics/registering-workflows/) | Programmatic workflow registration |
-| [workflow-input-output](basics/workflow-input-output/) | Passing data between tasks |
-| [understanding-workflows](basics/understanding-workflows/) | Workflow concepts and lifecycle |
-| [sdk-setup](basics/sdk-setup/) | SDK configuration and client setup |
-| [docker-setup](basics/docker-setup/) | Running Conductor with Docker |
-| [orkes-cloud](basics/orkes-cloud/) | Connecting to Orkes Cloud |
-| [conductor-ui](basics/conductor-ui/) | Using the Conductor UI |
-| [end-to-end-app](basics/end-to-end-app/) | Complete application walkthrough |
-
-### Agents & AI Patterns (12 examples)
-
-| Example | Description |
-|---------|-------------|
-| [function-calling](agents/function-calling/) | LLM-style function selection and execution |
-| [tool-use-basics](agents/tool-use-basics/) | Tool execution with Open-Meteo and Wikipedia APIs |
-| [tool-use-parallel](agents/tool-use-parallel/) | Parallel tool execution (weather, stocks, news) |
-| [chain-of-thought](agents/chain-of-thought/) | Step-by-step reasoning pipeline |
-| [react-agent](agents/react-agent/) | Reason-Act-Observe agent loop |
-| [agentic-loop](agents/agentic-loop/) | Autonomous agent with iteration control |
-| [plan-execute-agent](agents/plan-execute-agent/) | Plan then execute pattern |
-| [agent-supervisor](agents/agent-supervisor/) | Supervisor coordinating specialist agents |
-| [agent-collaboration](agents/agent-collaboration/) | Multi-agent collaboration |
-| [agent-handoff](agents/agent-handoff/) | Agent-to-agent task handoff |
-| [multi-agent-research](agents/multi-agent-research/) | Parallel research across sources |
-| [multi-agent-support](agents/multi-agent-support/) | Multi-tier customer support |
-
-### AI & LLM Workflows (14 examples)
-
-> **Note:** AI examples require API keys. Set `CONDUCTOR_OPENAI_API_KEY`, `CONDUCTOR_ANTHROPIC_API_KEY`, or `GOOGLE_API_KEY` as needed. Examples throw `IllegalStateException` if keys are missing.
-
-| Example | Description |
-|---------|-------------|
-| [first-ai-workflow](ai/first-ai-workflow/) | Minimal AI workflow |
-| [openai-gpt4](ai/openai-gpt4/) | OpenAI GPT-4 integration |
-| [anthropic-claude](ai/anthropic-claude/) | Anthropic Claude integration |
-| [google-gemini](ai/google-gemini/) | Google Gemini integration |
-| [basic-rag](ai/basic-rag/) | Basic retrieval-augmented generation |
-| [adaptive-rag](ai/adaptive-rag/) | Query-adaptive RAG routing |
-| [corrective-rag](ai/corrective-rag/) | RAG with relevance checking |
-| [rag-citation](ai/rag-citation/) | RAG with source citations |
-| [rag-hybrid-search](ai/rag-hybrid-search/) | BM25 + TF-IDF cosine hybrid search |
-| [document-ingestion](ai/document-ingestion/) | PDF extraction with Apache PDFBox |
-| [llm-chain](ai/llm-chain/) | Chained LLM calls |
-| [llm-fallback-chain](ai/llm-fallback-chain/) | LLM provider failover |
-| [llm-cost-tracking](ai/llm-cost-tracking/) | Token and cost tracking |
-| [structured-output](ai/structured-output/) | Structured JSON output from LLMs |
-
-### Task Patterns (8 examples)
-
-| Example | Description |
-|---------|-------------|
-| [fork-join](task-patterns/fork-join/) | Parallel execution with join |
-| [dynamic-fork](task-patterns/dynamic-fork/) | Runtime-determined parallel tasks |
-| [fan-out-fan-in](task-patterns/fan-out-fan-in/) | Dynamic fan-out with aggregation |
-| [sub-workflows](task-patterns/sub-workflows/) | Nested workflow execution |
-| [do-while](task-patterns/do-while/) | Loop until condition met |
-| [switch-task](task-patterns/switch-task/) | Conditional branching |
-| [wait-for-event](task-patterns/wait-for-event/) | External event triggers |
-| [rate-limiting](task-patterns/rate-limiting/) | Controlled execution rates |
-
-### Resilience (6 examples)
-
-| Example | Description |
-|---------|-------------|
-| [saga-pattern](resilience/saga-pattern/) | Distributed transactions with compensation |
-| [compensation-workflows](resilience/compensation-workflows/) | Compensating actions on failure |
-| [circuit-breaker](resilience/circuit-breaker/) | Circuit breaker pattern |
-| [dead-letter](resilience/dead-letter/) | Failed task handling |
-| [graceful-degradation](resilience/graceful-degradation/) | Fallback on service failure |
-| [workflow-recovery](resilience/workflow-recovery/) | Recovery from partial failures |
-
-### E-Commerce (5 examples)
-
-| Example | Description |
-|---------|-------------|
-| [checkout-flow](ecommerce/checkout-flow/) | End-to-end checkout |
-| [fraud-detection](ecommerce/fraud-detection/) | 7-factor fraud scoring model |
-| [inventory-management](ecommerce/inventory-management/) | CAS-based inventory with AtomicInteger |
-| [order-management](ecommerce/order-management/) | Order lifecycle management |
-| [payment-processing](ecommerce/payment-processing/) | Stripe SDK payment processing |
-
-### DevOps (6 examples)
-
-| Example | Description |
-|---------|-------------|
-| [ci-cd-pipeline](devops/ci-cd-pipeline/) | Build, test, deploy pipeline |
-| [certificate-rotation](devops/certificate-rotation/) | SSL certificate management |
-| [database-backup](devops/database-backup/) | PostgreSQL backup with pg_dump |
-| [incident-response](devops/incident-response/) | Automated incident handling |
-| [service-discovery-devops](devops/service-discovery-devops/) | Service registration and routing |
-| [uptime-monitor](devops/uptime-monitor/) | Endpoint health monitoring |
-
-### Microservices (5 examples)
-
-| Example | Description |
-|---------|-------------|
-| [api-gateway](microservices/api-gateway/) | API gateway pattern |
-| [blue-green-deploy](microservices/blue-green-deploy/) | Blue-green deployment |
-| [bulkhead-pattern](microservices/bulkhead-pattern/) | Bulkhead isolation |
-| [canary-deployment](microservices/canary-deployment/) | Canary release strategy |
-| [choreography-vs-orchestration](microservices/choreography-vs-orchestration/) | Pattern comparison |
-
-### Events (5 examples)
-
-| Example | Description |
-|---------|-------------|
-| [cdc-pipeline](events/cdc-pipeline/) | Change data capture |
-| [dead-letter-events](events/dead-letter-events/) | Dead letter event handling |
-| [event-driven-saga](events/event-driven-saga/) | Event-driven saga pattern |
-| [event-notification](events/event-notification/) | Event-based notifications |
-| [event-routing](events/event-routing/) | Content-based event routing |
-
-### Human-in-the-Loop (5 examples)
-
-| Example | Description |
-|---------|-------------|
-| [customer-onboarding-kyc](human-in-loop/customer-onboarding-kyc/) | KYC verification workflow |
-| [escalation-chain](human-in-loop/escalation-chain/) | Multi-level escalation |
-| [expense-approval](human-in-loop/expense-approval/) | Expense approval workflow |
-| [four-eyes-approval](human-in-loop/four-eyes-approval/) | Dual approval pattern |
-| [legal-contract-review](human-in-loop/legal-contract-review/) | Contract review with WAIT tasks |
-
-### Advanced (6 examples)
-
-| Example | Description |
-|---------|-------------|
-| [content-enricher](advanced/content-enricher/) | Content enrichment pipeline |
-| [exactly-once](advanced/exactly-once/) | Exactly-once processing |
-| [idempotent-processing](advanced/idempotent-processing/) | Idempotent task execution |
-| [map-reduce](advanced/map-reduce/) | MapReduce with Conductor |
-| [scatter-gather](advanced/scatter-gather/) | Scatter-gather aggregation |
-| [workflow-testing](advanced/workflow-testing/) | Workflow unit testing |
-
-### Security (3 examples)
-
-| Example | Description |
-|---------|-------------|
-| [gdpr-compliance](security/gdpr-compliance/) | GDPR data handling |
-| [secrets-management](security/secrets-management/) | Secret generation and management |
-| [vulnerability-scanning](security/vulnerability-scanning/) | Dependency vulnerability scanning |
-
-### Finance (3 examples)
-
-| Example | Description |
-|---------|-------------|
-| [account-opening](finance/account-opening/) | Account opening workflow |
-| [claims-processing](finance/claims-processing/) | Insurance claims processing |
-| [invoice-processing](finance/invoice-processing/) | Invoice OCR and validation |
-
-### Data (6 examples)
-
-| Example | Description |
-|---------|-------------|
-| [batch-processing](data/batch-processing/) | Batch data processing |
-| [csv-processing](data/csv-processing/) | CSV parsing and transformation |
-| [data-aggregation](data/data-aggregation/) | Data aggregation pipeline |
-| [data-enrichment](data/data-enrichment/) | Data enrichment workflow |
-| [data-quality-checks](data/data-quality-checks/) | Data quality validation |
-| [etl-basics](data/etl-basics/) | Extract-Transform-Load pipeline |
-
-### Scheduling (4 examples)
-
-| Example | Description |
-|---------|-------------|
-| [anomaly-detection](scheduling/anomaly-detection/) | Time-series anomaly detection |
-| [batch-scheduling](scheduling/batch-scheduling/) | Scheduled batch processing |
-| [cron-job-orchestration](scheduling/cron-job-orchestration/) | Cron-based job scheduling |
-| [deadline-management](scheduling/deadline-management/) | Deadline tracking and escalation |
-
-### Integrations (3 examples)
-
-> **Note:** Integration examples require external service credentials.
-
-| Example | Description |
-|---------|-------------|
-| [elasticsearch-integration](integrations/elasticsearch-integration/) | Elasticsearch indexing workflow |
-| [github-integration](integrations/github-integration/) | GitHub API integration |
-| [jira-integration](integrations/jira-integration/) | Jira issue management |
-
-### Other Domains
-
-| Category | Examples | Description |
-|----------|----------|-------------|
-| [crm/](crm/) | lead-scoring | Weighted lead scoring algorithm |
-| [healthcare/](healthcare/) | clinical-trials, patient-intake | Clinical trial management, patient onboarding |
-| [iot/](iot/) | asset-tracking, device-management | IoT device lifecycle |
-| [media/](media/) | video-processing | Video transcoding pipeline |
-| [supply-chain/](supply-chain/) | contract-lifecycle, procurement-workflow | Supply chain management |
-| [travel/](travel/) | travel-approval, travel-booking | Travel request and booking |
-| [user-mgmt/](user-mgmt/) | password-reset, user-onboarding | User management workflows |
-
-## Example Structure
-
-Each example is a standalone Maven project:
-
-```
-examples/basics/hello-world/
-├── pom.xml # Maven build (Java 21)
-├── run.sh # Launcher script
-├── README.md # Documentation
-├── src/main/java/helloworld/
-│ ├── HelloWorldExample.java # Main class
-│ ├── ConductorClientHelper.java # Client helper
-│ └── workers/
-│ └── GreetWorker.java # Worker implementation
-├── src/main/resources/
-│ └── workflow.json # Workflow definition
-└── src/test/java/helloworld/workers/
- └── GreetWorkerTest.java # Unit tests
-
-```
-
-All examples support `--workers` flag for worker-only mode (useful when starting workflows via CLI or UI).
-
-## Prerequisites
-
-- **Java 21+**
-- **Maven 3.8+**
-- **Conductor Server** — run locally via Docker or connect to [Orkes Cloud](https://orkes.io)
+## Running
 
 ```bash
 # Start Conductor locally
 docker run -d -p 8080:8080 -p 1234:5000 orkesio/orkes-conductor-standalone:latest
 
+export CONDUCTOR_SERVER_URL=http://localhost:8080/api
+
+./gradlew run --main-class <ClassName>
 ```
 
-## Legacy Examples
+## OSS-Compatible Examples
 
-The original Gradle-based examples are preserved in the [old/](old/) directory.
+These work with a plain OSS Conductor server — only `CONDUCTOR_SERVER_URL` required, no auth keys.
 
-## Learn More
+| Class | Description |
+|-------|-------------|
+| `com.netflix.conductor.gettingstarted.CreateWorkflow` | Register a workflow definition |
+| `com.netflix.conductor.gettingstarted.StartWorkflow` | Start a workflow |
+| `com.netflix.conductor.gettingstarted.HelloWorker` | Poll and execute tasks |
+| `com.netflix.conductor.sdk.examples.helloworld.Main` | End-to-end hello world |
+| `com.netflix.conductor.sdk.examples.TaskRunner` | Task polling with workers |
+| `com.netflix.conductor.sdk.examples.TaskRegistration` | Register task definitions |
+| `com.netflix.conductor.sdk.examples.events.EventHandlerExample` | Event handler registration |
+| `com.netflix.conductor.sdk.examples.events.EventListenerExample` | Event listener setup |
+| `com.netflix.conductor.sdk.examples.taskdomains.Main` | Task domain routing |
+| `com.netflix.conductor.sdk.examples.shipment.Main` | Shipment workflow |
+| `io.orkes.conductor.sdk.examples.WorkflowManagement` | Workflow CRUD operations |
+| `io.orkes.conductor.sdk.examples.WorkflowManagement2` | Workflow execution patterns |
+| `io.orkes.conductor.sdk.examples.workflowops.Main` | Workflow operations |
 
-- [Conductor Java SDK Documentation](../README.md)
-- [Worker SDK Guide](../java-sdk/worker_sdk.md)
-- [Workflow SDK Guide](../java-sdk/workflow_sdk.md)
-- [Official Conductor Documentation](https://orkes.io/content)
+## Orkes Cloud–Only Examples
 
----
+These require an Orkes Cloud server with `CONDUCTOR_AUTH_KEY` and `CONDUCTOR_AUTH_SECRET` set.
 
-> **How to run this example:** See [RUNNING.md](../RUNNING.md) for prerequisites, build commands, Docker setup, and CLI usage.
+| Class | Why Orkes-only |
+|-------|----------------|
+| `io.orkes.conductor.sdk.examples.AuthorizationManagement` | Uses Orkes authorization API |
+| `io.orkes.conductor.sdk.examples.SchedulerManagement` | Uses Orkes scheduler API |
+| `io.orkes.conductor.sdk.examples.MetadataManagement` | Uses `OrkesClients` metadata extensions |
+| `io.orkes.conductor.sdk.examples.agentic.FunctionCallingExample` | Requires LLM provider configured in server |
+| `io.orkes.conductor.sdk.examples.agentic.LlmChatExample` | Requires LLM provider configured in server |
+| `io.orkes.conductor.sdk.examples.agentic.RagWorkflowExample` | Requires vector DB + LLM integration |
+| `io.orkes.conductor.sdk.examples.agentic.VectorDbExample` | Requires vector DB integration |
+| `io.orkes.conductor.sdk.examples.agentic.HumanInLoopChatExample` | Requires LLM + human task integration |
+| `io.orkes.conductor.sdk.examples.agentic.AgenticExamplesRunner` | Runner for the agentic examples above |


### PR DESCRIPTION
## Summary

- Removes 258 lines of stale example descriptions from \`old/README.md\` — the previous content listed 118 Maven-based examples that don't exist in \`old/\` (they belong to the new \`examples/\` directory); the actual Gradle examples in \`old/\` were never documented
- Replaces with an accurate guide to the 22 real Gradle examples that live in \`old/\`, split into two tables: OSS-compatible (need only \`CONDUCTOR_SERVER_URL\`) and Orkes Cloud–only (require \`CONDUCTOR_AUTH_KEY\` + \`CONDUCTOR_AUTH_SECRET\`)
- Updates the Legacy Examples footer in \`examples/README.md\` to point readers to \`old/README.md\` for the breakdown

## User impact

A first-time OSS user landing on the legacy examples no longer has to guess which ones will crash without auth credentials. The README now tells them up front which 13 examples work with a plain local server and which 9 require an Orkes Cloud account.

Closes conductor-oss/java-sdk#96
Related: conductor-oss/getting-started#51 (helloworld auth confusion — auth portion resolved here, NPE portion fixed in #97)

## Test plan

- [ ] \`old/README.md\` renders correctly on GitHub (tables, links)
- [ ] OSS-compatible list verified against source (all use \`ConductorClient\` directly or via \`ClientUtil.getClient()\` + NPE fix from #94)
- [ ] Orkes-only list verified against source (\`getOrkesClients()\` or LLM task types)