### PR TITLE
fix: bump vulnerable deps in example pom.xml files

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
   push:
     branches: [main]
+  pull_request:          # TODO: remove before merge — temporary full-scan gate
+    branches: [main]
 
 permissions:
   actions: read

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -16,19 +16,3 @@ permissions:
 jobs:
   scan-scheduled:
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.3"
-    with:
-      # Scan only the published modules. examples/ pins old dependency versions and
-      # is excluded for now to keep the scan green. Add it back once examples are
-      # bumped to the same versions as the production modules.
-      scan-args: |-
-        -r
-        buildSrc
-        conductor-client
-        conductor-client-metrics
-        conductor-client-spring
-        conductor-client-spring-boot4
-        harness
-        java-sdk
-        orkes-client
-        orkes-spring
-        tests

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -5,9 +5,6 @@ on:
     - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
   push:
     branches: [main]
-  pull_request:          # TODO: remove before merge — temporary full-scan gate
-    branches: [main]
-
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -18,19 +18,3 @@ concurrency:
 jobs:
   scan-pr:
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.3"
-    with:
-      # Scan only the published modules. examples/ pins old dependency versions and
-      # is excluded for now to keep the scan green. Add it back once examples are
-      # bumped to the same versions as the production modules.
-      scan-args: |-
-        -r
-        buildSrc
-        conductor-client
-        conductor-client-metrics
-        conductor-client-spring
-        conductor-client-spring-boot4
-        harness
-        java-sdk
-        orkes-client
-        orkes-spring
-        tests

--- a/examples/advanced/aggregator-pattern/pom.xml
+++ b/examples/advanced/aggregator-pattern/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/at-least-once/pom.xml
+++ b/examples/advanced/at-least-once/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/backpressure/pom.xml
+++ b/examples/advanced/backpressure/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/batch-ml-training/pom.xml
+++ b/examples/advanced/batch-ml-training/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/claim-check/pom.xml
+++ b/examples/advanced/claim-check/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/competing-consumers/pom.xml
+++ b/examples/advanced/competing-consumers/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/container-orchestration/pom.xml
+++ b/examples/advanced/container-orchestration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/content-enricher/pom.xml
+++ b/examples/advanced/content-enricher/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/correlation-pattern/pom.xml
+++ b/examples/advanced/correlation-pattern/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/cross-region/pom.xml
+++ b/examples/advanced/cross-region/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/data-versioning/pom.xml
+++ b/examples/advanced/data-versioning/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/dynamic-workflows/pom.xml
+++ b/examples/advanced/dynamic-workflows/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/edge-orchestration/pom.xml
+++ b/examples/advanced/edge-orchestration/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/exactly-once/pom.xml
+++ b/examples/advanced/exactly-once/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/experiment-tracking/pom.xml
+++ b/examples/advanced/experiment-tracking/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/feature-store/pom.xml
+++ b/examples/advanced/feature-store/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/gpu-orchestration/pom.xml
+++ b/examples/advanced/gpu-orchestration/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/graceful-shutdown/pom.xml
+++ b/examples/advanced/graceful-shutdown/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/hybrid-cloud/pom.xml
+++ b/examples/advanced/hybrid-cloud/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/idempotent-processing/pom.xml
+++ b/examples/advanced/idempotent-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/map-reduce/pom.xml
+++ b/examples/advanced/map-reduce/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/message-broker/pom.xml
+++ b/examples/advanced/message-broker/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/model-registry/pom.xml
+++ b/examples/advanced/model-registry/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/model-serving/pom.xml
+++ b/examples/advanced/model-serving/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/multi-cluster/pom.xml
+++ b/examples/advanced/multi-cluster/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/normalizer/pom.xml
+++ b/examples/advanced/normalizer/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/ordered-processing/pom.xml
+++ b/examples/advanced/ordered-processing/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/parallel-processing/pom.xml
+++ b/examples/advanced/parallel-processing/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/pipeline-pattern/pom.xml
+++ b/examples/advanced/pipeline-pattern/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/pipeline-versioning/pom.xml
+++ b/examples/advanced/pipeline-versioning/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/publish-subscribe/pom.xml
+++ b/examples/advanced/publish-subscribe/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/request-reply/pom.xml
+++ b/examples/advanced/request-reply/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/scatter-gather/pom.xml
+++ b/examples/advanced/scatter-gather/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/serverless-orchestration/pom.xml
+++ b/examples/advanced/serverless-orchestration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/splitter-pattern/pom.xml
+++ b/examples/advanced/splitter-pattern/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/task-dedup/pom.xml
+++ b/examples/advanced/task-dedup/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/task-priority/pom.xml
+++ b/examples/advanced/task-priority/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/task-routing/pom.xml
+++ b/examples/advanced/task-routing/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/wire-tap/pom.xml
+++ b/examples/advanced/wire-tap/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/worker-pools/pom.xml
+++ b/examples/advanced/worker-pools/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/worker-scaling/pom.xml
+++ b/examples/advanced/worker-scaling/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/workflow-composition/pom.xml
+++ b/examples/advanced/workflow-composition/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/workflow-debugging/pom.xml
+++ b/examples/advanced/workflow-debugging/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/workflow-inheritance/pom.xml
+++ b/examples/advanced/workflow-inheritance/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/workflow-migration/pom.xml
+++ b/examples/advanced/workflow-migration/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/workflow-optimization/pom.xml
+++ b/examples/advanced/workflow-optimization/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/workflow-patterns/pom.xml
+++ b/examples/advanced/workflow-patterns/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/workflow-profiling/pom.xml
+++ b/examples/advanced/workflow-profiling/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/workflow-templating/pom.xml
+++ b/examples/advanced/workflow-templating/pom.xml
@@ -21,7 +21,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/advanced/workflow-testing/pom.xml
+++ b/examples/advanced/workflow-testing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/agent-collaboration/pom.xml
+++ b/examples/agents/agent-collaboration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/agent-handoff/pom.xml
+++ b/examples/agents/agent-handoff/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/agent-memory/pom.xml
+++ b/examples/agents/agent-memory/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/agent-supervisor/pom.xml
+++ b/examples/agents/agent-supervisor/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/agent-swarm/pom.xml
+++ b/examples/agents/agent-swarm/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/agentic-loop/pom.xml
+++ b/examples/agents/agentic-loop/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/api-calling-agent/pom.xml
+++ b/examples/agents/api-calling-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/autonomous-agent/pom.xml
+++ b/examples/agents/autonomous-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/calculator-agent/pom.xml
+++ b/examples/agents/calculator-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/calendar-agent/pom.xml
+++ b/examples/agents/calendar-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/chain-of-thought/pom.xml
+++ b/examples/agents/chain-of-thought/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/code-interpreter/pom.xml
+++ b/examples/agents/code-interpreter/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/competitive-agents/pom.xml
+++ b/examples/agents/competitive-agents/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/crm-agent/pom.xml
+++ b/examples/agents/crm-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/database-agent/pom.xml
+++ b/examples/agents/database-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/debate-agents/pom.xml
+++ b/examples/agents/debate-agents/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/email-agent/pom.xml
+++ b/examples/agents/email-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/file-processing-agent/pom.xml
+++ b/examples/agents/file-processing-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/function-calling/pom.xml
+++ b/examples/agents/function-calling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/goal-decomposition/pom.xml
+++ b/examples/agents/goal-decomposition/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/hierarchical-agents/pom.xml
+++ b/examples/agents/hierarchical-agents/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/multi-agent-code-review/pom.xml
+++ b/examples/agents/multi-agent-code-review/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/multi-agent-content/pom.xml
+++ b/examples/agents/multi-agent-content/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/multi-agent-planning/pom.xml
+++ b/examples/agents/multi-agent-planning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/multi-agent-research/pom.xml
+++ b/examples/agents/multi-agent-research/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/multi-agent-support/pom.xml
+++ b/examples/agents/multi-agent-support/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/plan-execute-agent/pom.xml
+++ b/examples/agents/plan-execute-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/react-agent/pom.xml
+++ b/examples/agents/react-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/reflection-agent/pom.xml
+++ b/examples/agents/reflection-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/search-agent/pom.xml
+++ b/examples/agents/search-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/self-correction/pom.xml
+++ b/examples/agents/self-correction/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/three-agent-pipeline/pom.xml
+++ b/examples/agents/three-agent-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-augmented-generation/pom.xml
+++ b/examples/agents/tool-augmented-generation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-use-basics/pom.xml
+++ b/examples/agents/tool-use-basics/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-use-caching/pom.xml
+++ b/examples/agents/tool-use-caching/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-use-conditional/pom.xml
+++ b/examples/agents/tool-use-conditional/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-use-error-handling/pom.xml
+++ b/examples/agents/tool-use-error-handling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-use-logging/pom.xml
+++ b/examples/agents/tool-use-logging/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-use-parallel/pom.xml
+++ b/examples/agents/tool-use-parallel/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-use-rate-limiting/pom.xml
+++ b/examples/agents/tool-use-rate-limiting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-use-sequential/pom.xml
+++ b/examples/agents/tool-use-sequential/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tool-use-validation/pom.xml
+++ b/examples/agents/tool-use-validation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/tree-of-thought/pom.xml
+++ b/examples/agents/tree-of-thought/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/two-agent-pipeline/pom.xml
+++ b/examples/agents/two-agent-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/agents/web-browsing-agent/pom.xml
+++ b/examples/agents/web-browsing-agent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-data-labeling/pom.xml
+++ b/examples/ai-generation/ai-data-labeling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-fine-tuning/pom.xml
+++ b/examples/ai-generation/ai-fine-tuning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-guardrails/pom.xml
+++ b/examples/ai-generation/ai-guardrails/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-image-generation/pom.xml
+++ b/examples/ai-generation/ai-image-generation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-model-evaluation/pom.xml
+++ b/examples/ai-generation/ai-model-evaluation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-music-generation/pom.xml
+++ b/examples/ai-generation/ai-music-generation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-orchestration-platform/pom.xml
+++ b/examples/ai-generation/ai-orchestration-platform/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-prompt-engineering/pom.xml
+++ b/examples/ai-generation/ai-prompt-engineering/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-video-generation/pom.xml
+++ b/examples/ai-generation/ai-video-generation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/ai-voice-cloning/pom.xml
+++ b/examples/ai-generation/ai-voice-cloning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai-generation/code-generation/pom.xml
+++ b/examples/ai-generation/code-generation/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai-generation/code-review-ai/pom.xml
+++ b/examples/ai-generation/code-review-ai/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai-generation/deployment-ai/pom.xml
+++ b/examples/ai-generation/deployment-ai/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai-generation/documentation-ai/pom.xml
+++ b/examples/ai-generation/documentation-ai/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai-generation/incident-ai/pom.xml
+++ b/examples/ai-generation/incident-ai/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai-generation/monitoring-ai/pom.xml
+++ b/examples/ai-generation/monitoring-ai/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai-generation/pr-review-ai/pom.xml
+++ b/examples/ai-generation/pr-review-ai/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai-generation/release-notes-ai/pom.xml
+++ b/examples/ai-generation/release-notes-ai/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai/adaptive-rag/pom.xml
+++ b/examples/ai/adaptive-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/amazon-bedrock/pom.xml
+++ b/examples/ai/amazon-bedrock/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/anthropic-claude/pom.xml
+++ b/examples/ai/anthropic-claude/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/basic-rag/pom.xml
+++ b/examples/ai/basic-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/chatbot-orchestration/pom.xml
+++ b/examples/ai/chatbot-orchestration/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai/cohere/pom.xml
+++ b/examples/ai/cohere/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/conversational-rag/pom.xml
+++ b/examples/ai/conversational-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/corrective-rag/pom.xml
+++ b/examples/ai/corrective-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/document-ingestion/pom.xml
+++ b/examples/ai/document-ingestion/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>

--- a/examples/ai/document-qa/pom.xml
+++ b/examples/ai/document-qa/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai/enterprise-rag/pom.xml
+++ b/examples/ai/enterprise-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/fine-tuned-deployment/pom.xml
+++ b/examples/ai/fine-tuned-deployment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/first-ai-workflow/pom.xml
+++ b/examples/ai/first-ai-workflow/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai/google-gemini/pom.xml
+++ b/examples/ai/google-gemini/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/huggingface/pom.xml
+++ b/examples/ai/huggingface/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/incremental-rag/pom.xml
+++ b/examples/ai/incremental-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/knowledge-base-sync/pom.xml
+++ b/examples/ai/knowledge-base-sync/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai/llm-caching/pom.xml
+++ b/examples/ai/llm-caching/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/llm-chain/pom.xml
+++ b/examples/ai/llm-chain/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/llm-cost-tracking/pom.xml
+++ b/examples/ai/llm-cost-tracking/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/llm-fallback-chain/pom.xml
+++ b/examples/ai/llm-fallback-chain/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/llm-retry/pom.xml
+++ b/examples/ai/llm-retry/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/mistral-ai/pom.xml
+++ b/examples/ai/mistral-ai/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/multi-document-rag/pom.xml
+++ b/examples/ai/multi-document-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/multi-model-compare/pom.xml
+++ b/examples/ai/multi-model-compare/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/multimodal-rag/pom.xml
+++ b/examples/ai/multimodal-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/ollama-local/pom.xml
+++ b/examples/ai/ollama-local/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/openai-gpt4/pom.xml
+++ b/examples/ai/openai-gpt4/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -35,6 +40,11 @@
             <groupId>com.theokanning.openai-gpt3-java</groupId>
             <artifactId>service</artifactId>
             <version>0.18.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>4.8.112</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/ai/prompt-templates/pom.xml
+++ b/examples/ai/prompt-templates/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/question-answering/pom.xml
+++ b/examples/ai/question-answering/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai/rag-access-control/pom.xml
+++ b/examples/ai/rag-access-control/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-chromadb/pom.xml
+++ b/examples/ai/rag-chromadb/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-citation/pom.xml
+++ b/examples/ai/rag-citation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-code/pom.xml
+++ b/examples/ai/rag-code/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-elasticsearch/pom.xml
+++ b/examples/ai/rag-elasticsearch/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-embedding-selection/pom.xml
+++ b/examples/ai/rag-embedding-selection/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-evaluation/pom.xml
+++ b/examples/ai/rag-evaluation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-fusion/pom.xml
+++ b/examples/ai/rag-fusion/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-hybrid-search/pom.xml
+++ b/examples/ai/rag-hybrid-search/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-knowledge-graph/pom.xml
+++ b/examples/ai/rag-knowledge-graph/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-langchain/pom.xml
+++ b/examples/ai/rag-langchain/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-milvus/pom.xml
+++ b/examples/ai/rag-milvus/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-mongodb/pom.xml
+++ b/examples/ai/rag-mongodb/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-multi-query/pom.xml
+++ b/examples/ai/rag-multi-query/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-pgvector/pom.xml
+++ b/examples/ai/rag-pgvector/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-pinecone/pom.xml
+++ b/examples/ai/rag-pinecone/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-qdrant/pom.xml
+++ b/examples/ai/rag-qdrant/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-quality-gates/pom.xml
+++ b/examples/ai/rag-quality-gates/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-redis/pom.xml
+++ b/examples/ai/rag-redis/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-reranking/pom.xml
+++ b/examples/ai/rag-reranking/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-sql/pom.xml
+++ b/examples/ai/rag-sql/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/rag-weaviate/pom.xml
+++ b/examples/ai/rag-weaviate/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/raptor-rag/pom.xml
+++ b/examples/ai/raptor-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/self-rag/pom.xml
+++ b/examples/ai/self-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/semi-structured-rag/pom.xml
+++ b/examples/ai/semi-structured-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/streaming-llm/pom.xml
+++ b/examples/ai/streaming-llm/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/structured-output/pom.xml
+++ b/examples/ai/structured-output/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/system-prompts/pom.xml
+++ b/examples/ai/system-prompts/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ai/voice-bot/pom.xml
+++ b/examples/ai/voice-bot/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/ai/web-scraping-rag/pom.xml
+++ b/examples/ai/web-scraping-rag/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/conductor-ui/pom.xml
+++ b/examples/basics/conductor-ui/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/creating-workers/pom.xml
+++ b/examples/basics/creating-workers/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/docker-setup/pom.xml
+++ b/examples/basics/docker-setup/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/end-to-end-app/pom.xml
+++ b/examples/basics/end-to-end-app/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/hello-world/pom.xml
+++ b/examples/basics/hello-world/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/hello-world/pom.xml
+++ b/examples/basics/hello-world/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.6</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/hello-world/pom.xml
+++ b/examples/basics/hello-world/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/orkes-cloud/pom.xml
+++ b/examples/basics/orkes-cloud/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/registering-workflows/pom.xml
+++ b/examples/basics/registering-workflows/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/sdk-setup/pom.xml
+++ b/examples/basics/sdk-setup/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/understanding-workflows/pom.xml
+++ b/examples/basics/understanding-workflows/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/basics/workflow-input-output/pom.xml
+++ b/examples/basics/workflow-input-output/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/crm/campaign-automation/pom.xml
+++ b/examples/crm/campaign-automation/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/crm/customer-journey/pom.xml
+++ b/examples/crm/customer-journey/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/crm/drip-campaign/pom.xml
+++ b/examples/crm/drip-campaign/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/crm/lead-nurturing/pom.xml
+++ b/examples/crm/lead-nurturing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/crm/lead-scoring/pom.xml
+++ b/examples/crm/lead-scoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/audio-transcription/pom.xml
+++ b/examples/data/audio-transcription/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/batch-processing/pom.xml
+++ b/examples/data/batch-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/clickstream-analytics/pom.xml
+++ b/examples/data/clickstream-analytics/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/csv-processing/pom.xml
+++ b/examples/data/csv-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/dashboard-data/pom.xml
+++ b/examples/data/dashboard-data/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-aggregation/pom.xml
+++ b/examples/data/data-aggregation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-anonymization/pom.xml
+++ b/examples/data/data-anonymization/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-archival/pom.xml
+++ b/examples/data/data-archival/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/data-catalog/pom.xml
+++ b/examples/data/data-catalog/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-compression/pom.xml
+++ b/examples/data/data-compression/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/data-dedup/pom.xml
+++ b/examples/data/data-dedup/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-enrichment/pom.xml
+++ b/examples/data/data-enrichment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-export/pom.xml
+++ b/examples/data/data-export/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-lake-ingestion/pom.xml
+++ b/examples/data/data-lake-ingestion/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/data-lineage/pom.xml
+++ b/examples/data/data-lineage/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/data-partitioning/pom.xml
+++ b/examples/data/data-partitioning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-quality-checks/pom.xml
+++ b/examples/data/data-quality-checks/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/data-reconciliation/pom.xml
+++ b/examples/data/data-reconciliation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-sampling/pom.xml
+++ b/examples/data/data-sampling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-sync/pom.xml
+++ b/examples/data/data-sync/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-validation/pom.xml
+++ b/examples/data/data-validation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/data-warehouse-load/pom.xml
+++ b/examples/data/data-warehouse-load/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/etl-basics/pom.xml
+++ b/examples/data/etl-basics/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/feature-engineering/pom.xml
+++ b/examples/data/feature-engineering/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/gdpr-data-deletion/pom.xml
+++ b/examples/data/gdpr-data-deletion/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/image-processing/pom.xml
+++ b/examples/data/image-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/json-transformation/pom.xml
+++ b/examples/data/json-transformation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/log-processing/pom.xml
+++ b/examples/data/log-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/ml-data-pipeline/pom.xml
+++ b/examples/data/ml-data-pipeline/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/named-entity-extraction/pom.xml
+++ b/examples/data/named-entity-extraction/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/ocr-pipeline/pom.xml
+++ b/examples/data/ocr-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/pdf-processing/pom.xml
+++ b/examples/data/pdf-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/real-time-analytics/pom.xml
+++ b/examples/data/real-time-analytics/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/report-generation/pom.xml
+++ b/examples/data/report-generation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/schema-evolution/pom.xml
+++ b/examples/data/schema-evolution/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/sentiment-analysis/pom.xml
+++ b/examples/data/sentiment-analysis/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/stream-processing/pom.xml
+++ b/examples/data/stream-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/summarization-pipeline/pom.xml
+++ b/examples/data/summarization-pipeline/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/text-classification/pom.xml
+++ b/examples/data/text-classification/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/data/video-transcoding/pom.xml
+++ b/examples/data/video-transcoding/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/data/xml-parsing/pom.xml
+++ b/examples/data/xml-parsing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/api-test-generation/pom.xml
+++ b/examples/devops/api-test-generation/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/devops/apm-workflow/pom.xml
+++ b/examples/devops/apm-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/artifact-management/pom.xml
+++ b/examples/devops/artifact-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/auto-scaling/pom.xml
+++ b/examples/devops/auto-scaling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/automated-testing/pom.xml
+++ b/examples/devops/automated-testing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/bug-triage/pom.xml
+++ b/examples/devops/bug-triage/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/devops/capacity-planning/pom.xml
+++ b/examples/devops/capacity-planning/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/certificate-rotation/pom.xml
+++ b/examples/devops/certificate-rotation/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/change-management/pom.xml
+++ b/examples/devops/change-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/chaos-engineering/pom.xml
+++ b/examples/devops/chaos-engineering/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/ci-cd-pipeline/pom.xml
+++ b/examples/devops/ci-cd-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/commit-analysis/pom.xml
+++ b/examples/devops/commit-analysis/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/devops/compliance-scanning/pom.xml
+++ b/examples/devops/compliance-scanning/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/cost-optimization/pom.xml
+++ b/examples/devops/cost-optimization/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/custom-metrics/pom.xml
+++ b/examples/devops/custom-metrics/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/database-backup/pom.xml
+++ b/examples/devops/database-backup/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/database-migration-devops/pom.xml
+++ b/examples/devops/database-migration-devops/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/dependency-update/pom.xml
+++ b/examples/devops/dependency-update/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/deployment-rollback/pom.xml
+++ b/examples/devops/deployment-rollback/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/disaster-recovery/pom.xml
+++ b/examples/devops/disaster-recovery/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/dns-management/pom.xml
+++ b/examples/devops/dns-management/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/environment-management/pom.xml
+++ b/examples/devops/environment-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/feature-environment/pom.xml
+++ b/examples/devops/feature-environment/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/gitops-workflow/pom.xml
+++ b/examples/devops/gitops-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/incident-response/pom.xml
+++ b/examples/devops/incident-response/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/infrastructure-provisioning/pom.xml
+++ b/examples/devops/infrastructure-provisioning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/load-balancer-config/pom.xml
+++ b/examples/devops/load-balancer-config/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/log-aggregation/pom.xml
+++ b/examples/devops/log-aggregation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/maintenance-window/pom.xml
+++ b/examples/devops/maintenance-window/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/metrics-collection/pom.xml
+++ b/examples/devops/metrics-collection/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/monitoring-alerting/pom.xml
+++ b/examples/devops/monitoring-alerting/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/multi-region-deploy/pom.xml
+++ b/examples/devops/multi-region-deploy/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/network-automation/pom.xml
+++ b/examples/devops/network-automation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/observability-pipeline/pom.xml
+++ b/examples/devops/observability-pipeline/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/on-call-rotation/pom.xml
+++ b/examples/devops/on-call-rotation/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/patch-management/pom.xml
+++ b/examples/devops/patch-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/performance-testing/pom.xml
+++ b/examples/devops/performance-testing/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/post-mortem-automation/pom.xml
+++ b/examples/devops/post-mortem-automation/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/predictive-monitoring/pom.xml
+++ b/examples/devops/predictive-monitoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/release-management/pom.xml
+++ b/examples/devops/release-management/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/rolling-update/pom.xml
+++ b/examples/devops/rolling-update/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/runbook-automation/pom.xml
+++ b/examples/devops/runbook-automation/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/service-discovery-devops/pom.xml
+++ b/examples/devops/service-discovery-devops/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/service-migration/pom.xml
+++ b/examples/devops/service-migration/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/sla-monitoring/pom.xml
+++ b/examples/devops/sla-monitoring/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/smoke-testing/pom.xml
+++ b/examples/devops/smoke-testing/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/test-generation/pom.xml
+++ b/examples/devops/test-generation/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/devops/threshold-alerting/pom.xml
+++ b/examples/devops/threshold-alerting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/devops/uptime-monitor/pom.xml
+++ b/examples/devops/uptime-monitor/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/abandoned-cart/pom.xml
+++ b/examples/ecommerce/abandoned-cart/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/auction-workflow/pom.xml
+++ b/examples/ecommerce/auction-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/checkout-flow/pom.xml
+++ b/examples/ecommerce/checkout-flow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/coupon-engine/pom.xml
+++ b/examples/ecommerce/coupon-engine/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/customer-segmentation/pom.xml
+++ b/examples/ecommerce/customer-segmentation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/flash-sale/pom.xml
+++ b/examples/ecommerce/flash-sale/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/fraud-detection/pom.xml
+++ b/examples/ecommerce/fraud-detection/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/inventory-management/pom.xml
+++ b/examples/ecommerce/inventory-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/loyalty-program/pom.xml
+++ b/examples/ecommerce/loyalty-program/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/marketplace-seller/pom.xml
+++ b/examples/ecommerce/marketplace-seller/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/order-management/pom.xml
+++ b/examples/ecommerce/order-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/payment-processing/pom.xml
+++ b/examples/ecommerce/payment-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/price-optimization/pom.xml
+++ b/examples/ecommerce/price-optimization/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/product-catalog/pom.xml
+++ b/examples/ecommerce/product-catalog/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/recommendation-engine/pom.xml
+++ b/examples/ecommerce/recommendation-engine/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/returns-processing/pom.xml
+++ b/examples/ecommerce/returns-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/shipping-workflow/pom.xml
+++ b/examples/ecommerce/shipping-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/shopping-cart/pom.xml
+++ b/examples/ecommerce/shopping-cart/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/subscription-billing/pom.xml
+++ b/examples/ecommerce/subscription-billing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/ecommerce/tax-calculation/pom.xml
+++ b/examples/ecommerce/tax-calculation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/assessment-creation/pom.xml
+++ b/examples/education/assessment-creation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/certificate-issuance/pom.xml
+++ b/examples/education/certificate-issuance/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/course-management/pom.xml
+++ b/examples/education/course-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/education-enrollment/pom.xml
+++ b/examples/education/education-enrollment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/grading-workflow/pom.xml
+++ b/examples/education/grading-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/lesson-planning/pom.xml
+++ b/examples/education/lesson-planning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/plagiarism-detection/pom.xml
+++ b/examples/education/plagiarism-detection/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/scholarship-processing/pom.xml
+++ b/examples/education/scholarship-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/student-progress/pom.xml
+++ b/examples/education/student-progress/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/education/tutoring-match/pom.xml
+++ b/examples/education/tutoring-match/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/cdc-pipeline/pom.xml
+++ b/examples/events/cdc-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/complex-event-processing/pom.xml
+++ b/examples/events/complex-event-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/cron-trigger/pom.xml
+++ b/examples/events/cron-trigger/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/dead-letter-events/pom.xml
+++ b/examples/events/dead-letter-events/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/delayed-event/pom.xml
+++ b/examples/events/delayed-event/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-aggregation/pom.xml
+++ b/examples/events/event-aggregation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-audit-trail/pom.xml
+++ b/examples/events/event-audit-trail/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-batching/pom.xml
+++ b/examples/events/event-batching/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-choreography/pom.xml
+++ b/examples/events/event-choreography/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-correlation/pom.xml
+++ b/examples/events/event-correlation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-dedup/pom.xml
+++ b/examples/events/event-dedup/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-driven-saga/pom.xml
+++ b/examples/events/event-driven-saga/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-driven-workflow/pom.xml
+++ b/examples/events/event-driven-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-fanout/pom.xml
+++ b/examples/events/event-fanout/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-filtering/pom.xml
+++ b/examples/events/event-filtering/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-management/pom.xml
+++ b/examples/events/event-management/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/events/event-merge/pom.xml
+++ b/examples/events/event-merge/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-monitoring/pom.xml
+++ b/examples/events/event-monitoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-notification/pom.xml
+++ b/examples/events/event-notification/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-ordering/pom.xml
+++ b/examples/events/event-ordering/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-priority/pom.xml
+++ b/examples/events/event-priority/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-replay-testing/pom.xml
+++ b/examples/events/event-replay-testing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-replay/pom.xml
+++ b/examples/events/event-replay/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-routing/pom.xml
+++ b/examples/events/event-routing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-schema-validation/pom.xml
+++ b/examples/events/event-schema-validation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-split/pom.xml
+++ b/examples/events/event-split/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-transformation/pom.xml
+++ b/examples/events/event-transformation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-ttl/pom.xml
+++ b/examples/events/event-ttl/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-versioning/pom.xml
+++ b/examples/events/event-versioning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/event-windowing/pom.xml
+++ b/examples/events/event-windowing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/kafka-consumer/pom.xml
+++ b/examples/events/kafka-consumer/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/pubsub-consumer/pom.xml
+++ b/examples/events/pubsub-consumer/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/scheduled-event/pom.xml
+++ b/examples/events/scheduled-event/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/sqs-consumer/pom.xml
+++ b/examples/events/sqs-consumer/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/webhook-callback/pom.xml
+++ b/examples/events/webhook-callback/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/webhook-rate-limiting/pom.xml
+++ b/examples/events/webhook-rate-limiting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/webhook-retry/pom.xml
+++ b/examples/events/webhook-retry/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/webhook-security/pom.xml
+++ b/examples/events/webhook-security/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/webhook-trigger/pom.xml
+++ b/examples/events/webhook-trigger/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/events/webinar-registration/pom.xml
+++ b/examples/events/webinar-registration/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/finance/account-opening/pom.xml
+++ b/examples/finance/account-opening/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/budget-approval/pom.xml
+++ b/examples/finance/budget-approval/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/claims-processing/pom.xml
+++ b/examples/finance/claims-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/credit-scoring/pom.xml
+++ b/examples/finance/credit-scoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/cryptocurrency-trading/pom.xml
+++ b/examples/finance/cryptocurrency-trading/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/expense-management/pom.xml
+++ b/examples/finance/expense-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/financial-audit/pom.xml
+++ b/examples/finance/financial-audit/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/insurance-underwriting/pom.xml
+++ b/examples/finance/insurance-underwriting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/investment-workflow/pom.xml
+++ b/examples/finance/investment-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/invoice-processing/pom.xml
+++ b/examples/finance/invoice-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/kyc-aml/pom.xml
+++ b/examples/finance/kyc-aml/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/loan-origination/pom.xml
+++ b/examples/finance/loan-origination/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/payment-reconciliation/pom.xml
+++ b/examples/finance/payment-reconciliation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/payroll-workflow/pom.xml
+++ b/examples/finance/payroll-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/portfolio-rebalancing/pom.xml
+++ b/examples/finance/portfolio-rebalancing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/regulatory-reporting/pom.xml
+++ b/examples/finance/regulatory-reporting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/risk-assessment/pom.xml
+++ b/examples/finance/risk-assessment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/tax-filing/pom.xml
+++ b/examples/finance/tax-filing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/trade-execution/pom.xml
+++ b/examples/finance/trade-execution/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/finance/wire-transfer/pom.xml
+++ b/examples/finance/wire-transfer/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/food/catering-management/pom.xml
+++ b/examples/food/catering-management/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/food/delivery-tracking/pom.xml
+++ b/examples/food/delivery-tracking/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/food/food-ordering/pom.xml
+++ b/examples/food/food-ordering/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/food/food-safety/pom.xml
+++ b/examples/food/food-safety/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/food/kitchen-workflow/pom.xml
+++ b/examples/food/kitchen-workflow/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/food/loyalty-rewards/pom.xml
+++ b/examples/food/loyalty-rewards/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/food/menu-management/pom.xml
+++ b/examples/food/menu-management/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/food/nutrition-tracking/pom.xml
+++ b/examples/food/nutrition-tracking/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/food/reservation-system/pom.xml
+++ b/examples/food/reservation-system/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/food/restaurant-management/pom.xml
+++ b/examples/food/restaurant-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/gaming/anti-cheat/pom.xml
+++ b/examples/gaming/anti-cheat/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/gaming/game-analytics/pom.xml
+++ b/examples/gaming/game-analytics/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/gaming/gaming-matchmaking/pom.xml
+++ b/examples/gaming/gaming-matchmaking/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/gaming/in-app-purchase/pom.xml
+++ b/examples/gaming/in-app-purchase/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/gaming/leaderboard-update/pom.xml
+++ b/examples/gaming/leaderboard-update/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/gaming/live-ops/pom.xml
+++ b/examples/gaming/live-ops/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/gaming/player-progression/pom.xml
+++ b/examples/gaming/player-progression/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/gaming/season-management/pom.xml
+++ b/examples/gaming/season-management/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/gaming/tournament-bracket/pom.xml
+++ b/examples/gaming/tournament-bracket/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/gaming/virtual-economy/pom.xml
+++ b/examples/gaming/virtual-economy/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/government/benefit-determination/pom.xml
+++ b/examples/government/benefit-determination/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/government/case-management-gov/pom.xml
+++ b/examples/government/case-management-gov/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/government/citizen-request/pom.xml
+++ b/examples/government/citizen-request/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/government/emergency-response/pom.xml
+++ b/examples/government/emergency-response/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/government/government-permit/pom.xml
+++ b/examples/government/government-permit/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/government/inspection-workflow/pom.xml
+++ b/examples/government/inspection-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/government/public-health/pom.xml
+++ b/examples/government/public-health/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/government/public-records/pom.xml
+++ b/examples/government/public-records/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/government/tax-assessment/pom.xml
+++ b/examples/government/tax-assessment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/government/voting-workflow/pom.xml
+++ b/examples/government/voting-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/appointment-scheduling/pom.xml
+++ b/examples/healthcare/appointment-scheduling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/billing-medical/pom.xml
+++ b/examples/healthcare/billing-medical/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/care-coordination/pom.xml
+++ b/examples/healthcare/care-coordination/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/clinical-decision/pom.xml
+++ b/examples/healthcare/clinical-decision/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/clinical-trials/pom.xml
+++ b/examples/healthcare/clinical-trials/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/discharge-planning/pom.xml
+++ b/examples/healthcare/discharge-planning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/drug-interaction/pom.xml
+++ b/examples/healthcare/drug-interaction/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/ehr-integration/pom.xml
+++ b/examples/healthcare/ehr-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/genomics-pipeline/pom.xml
+++ b/examples/healthcare/genomics-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/insurance-claims/pom.xml
+++ b/examples/healthcare/insurance-claims/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/lab-results/pom.xml
+++ b/examples/healthcare/lab-results/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/medical-imaging/pom.xml
+++ b/examples/healthcare/medical-imaging/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/mental-health/pom.xml
+++ b/examples/healthcare/mental-health/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/patient-intake/pom.xml
+++ b/examples/healthcare/patient-intake/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/population-health/pom.xml
+++ b/examples/healthcare/population-health/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/prescription-workflow/pom.xml
+++ b/examples/healthcare/prescription-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/prior-authorization/pom.xml
+++ b/examples/healthcare/prior-authorization/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/referral-management/pom.xml
+++ b/examples/healthcare/referral-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/remote-monitoring/pom.xml
+++ b/examples/healthcare/remote-monitoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/healthcare/telemedicine/pom.xml
+++ b/examples/healthcare/telemedicine/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/background-check/pom.xml
+++ b/examples/hr/background-check/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/benefits-enrollment/pom.xml
+++ b/examples/hr/benefits-enrollment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/hr-onboarding/pom.xml
+++ b/examples/hr/hr-onboarding/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/interview-scheduling/pom.xml
+++ b/examples/hr/interview-scheduling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/leave-management/pom.xml
+++ b/examples/hr/leave-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/offer-management/pom.xml
+++ b/examples/hr/offer-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/performance-review/pom.xml
+++ b/examples/hr/performance-review/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/recruitment-pipeline/pom.xml
+++ b/examples/hr/recruitment-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/time-tracking/pom.xml
+++ b/examples/hr/time-tracking/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/hr/training-management/pom.xml
+++ b/examples/hr/training-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/approval-comments/pom.xml
+++ b/examples/human-in-loop/approval-comments/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/approval-dashboard-nextjs/pom.xml
+++ b/examples/human-in-loop/approval-dashboard-nextjs/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/approval-dashboard-react/pom.xml
+++ b/examples/human-in-loop/approval-dashboard-react/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/approval-delegation/pom.xml
+++ b/examples/human-in-loop/approval-delegation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/conditional-approval/pom.xml
+++ b/examples/human-in-loop/conditional-approval/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/content-review-pipeline/pom.xml
+++ b/examples/human-in-loop/content-review-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/customer-onboarding-kyc/pom.xml
+++ b/examples/human-in-loop/customer-onboarding-kyc/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/document-verification/pom.xml
+++ b/examples/human-in-loop/document-verification/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/email-approval/pom.xml
+++ b/examples/human-in-loop/email-approval/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/escalation-chain/pom.xml
+++ b/examples/human-in-loop/escalation-chain/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/escalation-timer/pom.xml
+++ b/examples/human-in-loop/escalation-timer/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/exception-handling/pom.xml
+++ b/examples/human-in-loop/exception-handling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/expense-approval/pom.xml
+++ b/examples/human-in-loop/expense-approval/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/four-eyes-approval/pom.xml
+++ b/examples/human-in-loop/four-eyes-approval/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/helpdesk-routing/pom.xml
+++ b/examples/human-in-loop/helpdesk-routing/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/human-in-loop/human-group-claim/pom.xml
+++ b/examples/human-in-loop/human-group-claim/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/human-task/pom.xml
+++ b/examples/human-in-loop/human-task/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/human-user-assignment/pom.xml
+++ b/examples/human-in-loop/human-user-assignment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/legal-contract-review/pom.xml
+++ b/examples/human-in-loop/legal-contract-review/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/medical-records-review/pom.xml
+++ b/examples/human-in-loop/medical-records-review/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/mobile-approval-flutter/pom.xml
+++ b/examples/human-in-loop/mobile-approval-flutter/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/multi-level-approval/pom.xml
+++ b/examples/human-in-loop/multi-level-approval/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/multi-tenant-approval/pom.xml
+++ b/examples/human-in-loop/multi-tenant-approval/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/quality-gate/pom.xml
+++ b/examples/human-in-loop/quality-gate/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/slack-approval/pom.xml
+++ b/examples/human-in-loop/slack-approval/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/ticket-management/pom.xml
+++ b/examples/human-in-loop/ticket-management/pom.xml
@@ -12,7 +12,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/human-in-loop/training-data-labeling/pom.xml
+++ b/examples/human-in-loop/training-data-labeling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/wait-rest-api/pom.xml
+++ b/examples/human-in-loop/wait-rest-api/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/wait-sdk/pom.xml
+++ b/examples/human-in-loop/wait-sdk/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/wait-task-basics/pom.xml
+++ b/examples/human-in-loop/wait-task-basics/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/human-in-loop/wait-timeout-escalation/pom.xml
+++ b/examples/human-in-loop/wait-timeout-escalation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/actuarial-workflow/pom.xml
+++ b/examples/insurance/actuarial-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/agency-management/pom.xml
+++ b/examples/insurance/agency-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/commission-insurance/pom.xml
+++ b/examples/insurance/commission-insurance/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/compliance-insurance/pom.xml
+++ b/examples/insurance/compliance-insurance/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/endorsement-processing/pom.xml
+++ b/examples/insurance/endorsement-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/insurance-renewal/pom.xml
+++ b/examples/insurance/insurance-renewal/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/policy-issuance/pom.xml
+++ b/examples/insurance/policy-issuance/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/premium-calculation/pom.xml
+++ b/examples/insurance/premium-calculation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/reinsurance/pom.xml
+++ b/examples/insurance/reinsurance/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/insurance/salvage-recovery/pom.xml
+++ b/examples/insurance/salvage-recovery/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/aws-integration/pom.xml
+++ b/examples/integrations/aws-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/azure-integration/pom.xml
+++ b/examples/integrations/azure-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/cloudwatch-integration/pom.xml
+++ b/examples/integrations/cloudwatch-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/database-integration/pom.xml
+++ b/examples/integrations/database-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/elasticsearch-integration/pom.xml
+++ b/examples/integrations/elasticsearch-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/gcp-integration/pom.xml
+++ b/examples/integrations/gcp-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/github-integration/pom.xml
+++ b/examples/integrations/github-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/hubspot-integration/pom.xml
+++ b/examples/integrations/hubspot-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/jira-integration/pom.xml
+++ b/examples/integrations/jira-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/lambda-integration/pom.xml
+++ b/examples/integrations/lambda-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/redis-integration/pom.xml
+++ b/examples/integrations/redis-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/s3-integration/pom.xml
+++ b/examples/integrations/s3-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/salesforce-integration/pom.xml
+++ b/examples/integrations/salesforce-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/sendgrid-integration/pom.xml
+++ b/examples/integrations/sendgrid-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/slack-integration/pom.xml
+++ b/examples/integrations/slack-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/sns-sqs-integration/pom.xml
+++ b/examples/integrations/sns-sqs-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/stripe-integration/pom.xml
+++ b/examples/integrations/stripe-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/teams-integration/pom.xml
+++ b/examples/integrations/teams-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/twilio-integration/pom.xml
+++ b/examples/integrations/twilio-integration/pom.xml
@@ -27,9 +27,19 @@
             <version>10.1.5</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.14.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/integrations/zendesk-integration/pom.xml
+++ b/examples/integrations/zendesk-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/agriculture-iot/pom.xml
+++ b/examples/iot/agriculture-iot/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/air-quality/pom.xml
+++ b/examples/iot/air-quality/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/asset-tracking/pom.xml
+++ b/examples/iot/asset-tracking/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/building-automation/pom.xml
+++ b/examples/iot/building-automation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/connected-vehicles/pom.xml
+++ b/examples/iot/connected-vehicles/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/device-management/pom.xml
+++ b/examples/iot/device-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/edge-computing/pom.xml
+++ b/examples/iot/edge-computing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/energy-management/pom.xml
+++ b/examples/iot/energy-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/environmental-monitoring/pom.xml
+++ b/examples/iot/environmental-monitoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/firmware-update/pom.xml
+++ b/examples/iot/firmware-update/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/fleet-management/pom.xml
+++ b/examples/iot/fleet-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/geofencing/pom.xml
+++ b/examples/iot/geofencing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/industrial-iot/pom.xml
+++ b/examples/iot/industrial-iot/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/iot-security/pom.xml
+++ b/examples/iot/iot-security/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/predictive-maintenance/pom.xml
+++ b/examples/iot/predictive-maintenance/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/sensor-data-processing/pom.xml
+++ b/examples/iot/sensor-data-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/smart-home/pom.xml
+++ b/examples/iot/smart-home/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/supply-chain-iot/pom.xml
+++ b/examples/iot/supply-chain-iot/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/water-management/pom.xml
+++ b/examples/iot/water-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/iot/wearable-data/pom.xml
+++ b/examples/iot/wearable-data/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/compliance-review/pom.xml
+++ b/examples/legal/compliance-review/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/contract-analysis/pom.xml
+++ b/examples/legal/contract-analysis/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/document-review/pom.xml
+++ b/examples/legal/document-review/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/e-discovery/pom.xml
+++ b/examples/legal/e-discovery/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/legal-billing/pom.xml
+++ b/examples/legal/legal-billing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/legal-case-management/pom.xml
+++ b/examples/legal/legal-case-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/litigation-hold/pom.xml
+++ b/examples/legal/litigation-hold/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/patent-filing/pom.xml
+++ b/examples/legal/patent-filing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/regulatory-filing/pom.xml
+++ b/examples/legal/regulatory-filing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/legal/trademark-search/pom.xml
+++ b/examples/legal/trademark-search/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/ab-testing/pom.xml
+++ b/examples/media/ab-testing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/advertising-workflow/pom.xml
+++ b/examples/media/advertising-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/analytics-reporting/pom.xml
+++ b/examples/media/analytics-reporting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/content-archival/pom.xml
+++ b/examples/media/content-archival/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/content-moderation/pom.xml
+++ b/examples/media/content-moderation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/content-publishing/pom.xml
+++ b/examples/media/content-publishing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/content-recommendation/pom.xml
+++ b/examples/media/content-recommendation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/content-syndication/pom.xml
+++ b/examples/media/content-syndication/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/digital-asset-management/pom.xml
+++ b/examples/media/digital-asset-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/email-campaign/pom.xml
+++ b/examples/media/email-campaign/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/image-pipeline/pom.xml
+++ b/examples/media/image-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/live-streaming/pom.xml
+++ b/examples/media/live-streaming/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/personalization/pom.xml
+++ b/examples/media/personalization/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/podcast-workflow/pom.xml
+++ b/examples/media/podcast-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/rights-management/pom.xml
+++ b/examples/media/rights-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/seo-workflow/pom.xml
+++ b/examples/media/seo-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/social-media/pom.xml
+++ b/examples/media/social-media/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/translation-pipeline/pom.xml
+++ b/examples/media/translation-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/user-generated-content/pom.xml
+++ b/examples/media/user-generated-content/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/media/video-processing/pom.xml
+++ b/examples/media/video-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/api-gateway-routing/pom.xml
+++ b/examples/microservices/api-gateway-routing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/api-gateway/pom.xml
+++ b/examples/microservices/api-gateway/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/backend-for-frontend/pom.xml
+++ b/examples/microservices/backend-for-frontend/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/blue-green-deploy/pom.xml
+++ b/examples/microservices/blue-green-deploy/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/blue-green-deployment/pom.xml
+++ b/examples/microservices/blue-green-deployment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/bulkhead-pattern/pom.xml
+++ b/examples/microservices/bulkhead-pattern/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/canary-deployment/pom.xml
+++ b/examples/microservices/canary-deployment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/canary-release/pom.xml
+++ b/examples/microservices/canary-release/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/centralized-config-management/pom.xml
+++ b/examples/microservices/centralized-config-management/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/choreography-vs-orchestration/pom.xml
+++ b/examples/microservices/choreography-vs-orchestration/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/circuit-breaker-microservice/pom.xml
+++ b/examples/microservices/circuit-breaker-microservice/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/config-management/pom.xml
+++ b/examples/microservices/config-management/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/cqrs-pattern/pom.xml
+++ b/examples/microservices/cqrs-pattern/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/data-migration/pom.xml
+++ b/examples/microservices/data-migration/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/database-per-service/pom.xml
+++ b/examples/microservices/database-per-service/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/distributed-locking/pom.xml
+++ b/examples/microservices/distributed-locking/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/distributed-tracing/pom.xml
+++ b/examples/microservices/distributed-tracing/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/distributed-transactions/pom.xml
+++ b/examples/microservices/distributed-transactions/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/event-driven-microservices/pom.xml
+++ b/examples/microservices/event-driven-microservices/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/event-sourcing/pom.xml
+++ b/examples/microservices/event-sourcing/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/feature-flag-rollout/pom.xml
+++ b/examples/microservices/feature-flag-rollout/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/feature-flags/pom.xml
+++ b/examples/microservices/feature-flags/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/graceful-service-shutdown/pom.xml
+++ b/examples/microservices/graceful-service-shutdown/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/health-check-aggregation/pom.xml
+++ b/examples/microservices/health-check-aggregation/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/health-checks/pom.xml
+++ b/examples/microservices/health-checks/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/idempotent-operations/pom.xml
+++ b/examples/microservices/idempotent-operations/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/inter-service-communication/pom.xml
+++ b/examples/microservices/inter-service-communication/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/load-balancing/pom.xml
+++ b/examples/microservices/load-balancing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/multi-tenancy/pom.xml
+++ b/examples/microservices/multi-tenancy/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/outbox-pattern/pom.xml
+++ b/examples/microservices/outbox-pattern/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/rate-limiter-microservice/pom.xml
+++ b/examples/microservices/rate-limiter-microservice/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/request-aggregation/pom.xml
+++ b/examples/microservices/request-aggregation/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/secret-rotation/pom.xml
+++ b/examples/microservices/secret-rotation/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/service-decomposition/pom.xml
+++ b/examples/microservices/service-decomposition/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/service-discovery/pom.xml
+++ b/examples/microservices/service-discovery/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/service-mesh-orchestration/pom.xml
+++ b/examples/microservices/service-mesh-orchestration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/service-orchestration/pom.xml
+++ b/examples/microservices/service-orchestration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/service-registry/pom.xml
+++ b/examples/microservices/service-registry/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/microservices/service-versioning/pom.xml
+++ b/examples/microservices/service-versioning/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/microservices/shared-nothing-architecture/pom.xml
+++ b/examples/microservices/shared-nothing-architecture/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/beneficiary-tracking/pom.xml
+++ b/examples/nonprofit/beneficiary-tracking/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/compliance-nonprofit/pom.xml
+++ b/examples/nonprofit/compliance-nonprofit/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/donor-management/pom.xml
+++ b/examples/nonprofit/donor-management/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/event-fundraising/pom.xml
+++ b/examples/nonprofit/event-fundraising/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/fundraising-campaign/pom.xml
+++ b/examples/nonprofit/fundraising-campaign/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/grant-management/pom.xml
+++ b/examples/nonprofit/grant-management/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/impact-reporting/pom.xml
+++ b/examples/nonprofit/impact-reporting/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/nonprofit-donation/pom.xml
+++ b/examples/nonprofit/nonprofit-donation/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/program-evaluation/pom.xml
+++ b/examples/nonprofit/program-evaluation/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/nonprofit/volunteer-coordination/pom.xml
+++ b/examples/nonprofit/volunteer-coordination/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/project-mgmt/change-request/pom.xml
+++ b/examples/project-mgmt/change-request/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/project-mgmt/milestone-tracking/pom.xml
+++ b/examples/project-mgmt/milestone-tracking/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/project-mgmt/project-closure/pom.xml
+++ b/examples/project-mgmt/project-closure/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/project-mgmt/project-kickoff/pom.xml
+++ b/examples/project-mgmt/project-kickoff/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/project-mgmt/resource-allocation/pom.xml
+++ b/examples/project-mgmt/resource-allocation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/project-mgmt/retrospective/pom.xml
+++ b/examples/project-mgmt/retrospective/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/project-mgmt/risk-management/pom.xml
+++ b/examples/project-mgmt/risk-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/project-mgmt/sprint-planning/pom.xml
+++ b/examples/project-mgmt/sprint-planning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/project-mgmt/stakeholder-reporting/pom.xml
+++ b/examples/project-mgmt/stakeholder-reporting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/project-mgmt/task-assignment/pom.xml
+++ b/examples/project-mgmt/task-assignment/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/commission-calculation/pom.xml
+++ b/examples/real-estate/commission-calculation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/escrow-management/pom.xml
+++ b/examples/real-estate/escrow-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/lease-management/pom.xml
+++ b/examples/real-estate/lease-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/maintenance-request/pom.xml
+++ b/examples/real-estate/maintenance-request/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/mortgage-application/pom.xml
+++ b/examples/real-estate/mortgage-application/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/property-inspection/pom.xml
+++ b/examples/real-estate/property-inspection/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/property-valuation/pom.xml
+++ b/examples/real-estate/property-valuation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/real-estate-listing/pom.xml
+++ b/examples/real-estate/real-estate-listing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/tenant-screening/pom.xml
+++ b/examples/real-estate/tenant-screening/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/real-estate/title-search/pom.xml
+++ b/examples/real-estate/title-search/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/circuit-breaker/pom.xml
+++ b/examples/resilience/circuit-breaker/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/compensation-workflows/pom.xml
+++ b/examples/resilience/compensation-workflows/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/dead-letter/pom.xml
+++ b/examples/resilience/dead-letter/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/error-classification/pom.xml
+++ b/examples/resilience/error-classification/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/error-notification/pom.xml
+++ b/examples/resilience/error-notification/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/exponential-max-retry/pom.xml
+++ b/examples/resilience/exponential-max-retry/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/failure-workflow/pom.xml
+++ b/examples/resilience/failure-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/fallback-tasks/pom.xml
+++ b/examples/resilience/fallback-tasks/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/graceful-degradation/pom.xml
+++ b/examples/resilience/graceful-degradation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/idempotent-workers/pom.xml
+++ b/examples/resilience/idempotent-workers/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/multi-step-compensation/pom.xml
+++ b/examples/resilience/multi-step-compensation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/network-partitions/pom.xml
+++ b/examples/resilience/network-partitions/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/optional-tasks/pom.xml
+++ b/examples/resilience/optional-tasks/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/partial-failure-recovery/pom.xml
+++ b/examples/resilience/partial-failure-recovery/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/per-task-retry/pom.xml
+++ b/examples/resilience/per-task-retry/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/poll-timeout/pom.xml
+++ b/examples/resilience/poll-timeout/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/response-timeout/pom.xml
+++ b/examples/resilience/response-timeout/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/retry-exponential/pom.xml
+++ b/examples/resilience/retry-exponential/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/retry-fixed/pom.xml
+++ b/examples/resilience/retry-fixed/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/retry-jitter/pom.xml
+++ b/examples/resilience/retry-jitter/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/retry-linear/pom.xml
+++ b/examples/resilience/retry-linear/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/saga-fork-join/pom.xml
+++ b/examples/resilience/saga-fork-join/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/saga-pattern/pom.xml
+++ b/examples/resilience/saga-pattern/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/saga-payment-inventory/pom.xml
+++ b/examples/resilience/saga-payment-inventory/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/self-healing/pom.xml
+++ b/examples/resilience/self-healing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/timeout-policies/pom.xml
+++ b/examples/resilience/timeout-policies/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/transient-vs-permanent/pom.xml
+++ b/examples/resilience/transient-vs-permanent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/worker-health-checks/pom.xml
+++ b/examples/resilience/worker-health-checks/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/workflow-recovery/pom.xml
+++ b/examples/resilience/workflow-recovery/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/resilience/workflow-timeout/pom.xml
+++ b/examples/resilience/workflow-timeout/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/alerting-pipeline/pom.xml
+++ b/examples/scheduling/alerting-pipeline/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/anomaly-detection/pom.xml
+++ b/examples/scheduling/anomaly-detection/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/batch-scheduling/pom.xml
+++ b/examples/scheduling/batch-scheduling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/calendar-integration/pom.xml
+++ b/examples/scheduling/calendar-integration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/capacity-monitoring/pom.xml
+++ b/examples/scheduling/capacity-monitoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/change-tracking/pom.xml
+++ b/examples/scheduling/change-tracking/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/compliance-monitoring/pom.xml
+++ b/examples/scheduling/compliance-monitoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/cost-monitoring/pom.xml
+++ b/examples/scheduling/cost-monitoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/cron-job-orchestration/pom.xml
+++ b/examples/scheduling/cron-job-orchestration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/deadline-management/pom.xml
+++ b/examples/scheduling/deadline-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/dependency-mapping/pom.xml
+++ b/examples/scheduling/dependency-mapping/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/distributed-logging/pom.xml
+++ b/examples/scheduling/distributed-logging/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/health-dashboard/pom.xml
+++ b/examples/scheduling/health-dashboard/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/maintenance-windows/pom.xml
+++ b/examples/scheduling/maintenance-windows/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/performance-profiling/pom.xml
+++ b/examples/scheduling/performance-profiling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/recurring-billing/pom.xml
+++ b/examples/scheduling/recurring-billing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/root-cause-analysis/pom.xml
+++ b/examples/scheduling/root-cause-analysis/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/scheduled-reports/pom.xml
+++ b/examples/scheduling/scheduled-reports/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/sla-scheduling/pom.xml
+++ b/examples/scheduling/sla-scheduling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/time-based-triggers/pom.xml
+++ b/examples/scheduling/time-based-triggers/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/timezone-handling/pom.xml
+++ b/examples/scheduling/timezone-handling/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/trace-collection/pom.xml
+++ b/examples/scheduling/trace-collection/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/uptime-monitoring/pom.xml
+++ b/examples/scheduling/uptime-monitoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/scheduling/user-behavior-analytics/pom.xml
+++ b/examples/scheduling/user-behavior-analytics/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/access-review/pom.xml
+++ b/examples/security/access-review/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/api-key-rotation/pom.xml
+++ b/examples/security/api-key-rotation/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/security/audit-logging/pom.xml
+++ b/examples/security/audit-logging/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/authentication-workflow/pom.xml
+++ b/examples/security/authentication-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/authorization-rbac/pom.xml
+++ b/examples/security/authorization-rbac/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/certificate-management/pom.xml
+++ b/examples/security/certificate-management/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/compliance-reporting/pom.xml
+++ b/examples/security/compliance-reporting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/data-classification/pom.xml
+++ b/examples/security/data-classification/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/data-encryption/pom.xml
+++ b/examples/security/data-encryption/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/data-masking/pom.xml
+++ b/examples/security/data-masking/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/ddos-mitigation/pom.xml
+++ b/examples/security/ddos-mitigation/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/devsecops-pipeline/pom.xml
+++ b/examples/security/devsecops-pipeline/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/gdpr-compliance/pom.xml
+++ b/examples/security/gdpr-compliance/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/identity-provisioning/pom.xml
+++ b/examples/security/identity-provisioning/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/intrusion-detection/pom.xml
+++ b/examples/security/intrusion-detection/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/network-segmentation/pom.xml
+++ b/examples/security/network-segmentation/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/oauth-token-management/pom.xml
+++ b/examples/security/oauth-token-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/penetration-testing/pom.xml
+++ b/examples/security/penetration-testing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/privileged-access/pom.xml
+++ b/examples/security/privileged-access/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/secrets-management/pom.xml
+++ b/examples/security/secrets-management/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/security-incident/pom.xml
+++ b/examples/security/security-incident/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/security-orchestration/pom.xml
+++ b/examples/security/security-orchestration/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/security-posture/pom.xml
+++ b/examples/security/security-posture/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/security-training/pom.xml
+++ b/examples/security/security-training/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/soc2-automation/pom.xml
+++ b/examples/security/soc2-automation/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/threat-intelligence/pom.xml
+++ b/examples/security/threat-intelligence/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/vendor-risk/pom.xml
+++ b/examples/security/vendor-risk/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/vulnerability-scanning/pom.xml
+++ b/examples/security/vulnerability-scanning/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/waf-management/pom.xml
+++ b/examples/security/waf-management/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/security/zero-trust-verification/pom.xml
+++ b/examples/security/zero-trust-verification/pom.xml
@@ -25,7 +25,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/supply-chain/bid-management/pom.xml
+++ b/examples/supply-chain/bid-management/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/cold-chain/pom.xml
+++ b/examples/supply-chain/cold-chain/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/compliance-vendor/pom.xml
+++ b/examples/supply-chain/compliance-vendor/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/contract-lifecycle/pom.xml
+++ b/examples/supply-chain/contract-lifecycle/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/customs-clearance/pom.xml
+++ b/examples/supply-chain/customs-clearance/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/demand-forecasting/pom.xml
+++ b/examples/supply-chain/demand-forecasting/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/freight-management/pom.xml
+++ b/examples/supply-chain/freight-management/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/goods-receipt/pom.xml
+++ b/examples/supply-chain/goods-receipt/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/supply-chain/inventory-optimization/pom.xml
+++ b/examples/supply-chain/inventory-optimization/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/last-mile-delivery/pom.xml
+++ b/examples/supply-chain/last-mile-delivery/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/logistics-optimization/pom.xml
+++ b/examples/supply-chain/logistics-optimization/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/procurement-workflow/pom.xml
+++ b/examples/supply-chain/procurement-workflow/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/supply-chain/purchase-order/pom.xml
+++ b/examples/supply-chain/purchase-order/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/supply-chain/quality-inspection/pom.xml
+++ b/examples/supply-chain/quality-inspection/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/reverse-logistics/pom.xml
+++ b/examples/supply-chain/reverse-logistics/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/rfp-automation/pom.xml
+++ b/examples/supply-chain/rfp-automation/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/supplier-evaluation/pom.xml
+++ b/examples/supply-chain/supplier-evaluation/pom.xml
@@ -5,7 +5,12 @@
     <properties><maven.compiler.source>21</maven.compiler.source><maven.compiler.target>21</maven.compiler.target><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/supply-chain/supply-chain-mgmt/pom.xml
+++ b/examples/supply-chain/supply-chain-mgmt/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/supply-chain/vendor-onboarding/pom.xml
+++ b/examples/supply-chain/vendor-onboarding/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/supply-chain/warehouse-management/pom.xml
+++ b/examples/supply-chain/warehouse-management/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/task-patterns/bulk-operations/pom.xml
+++ b/examples/task-patterns/bulk-operations/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/chaining-http-tasks/pom.xml
+++ b/examples/task-patterns/chaining-http-tasks/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/do-while/pom.xml
+++ b/examples/task-patterns/do-while/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/dynamic-fork/pom.xml
+++ b/examples/task-patterns/dynamic-fork/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/event-handlers/pom.xml
+++ b/examples/task-patterns/event-handlers/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/exclusive-join/pom.xml
+++ b/examples/task-patterns/exclusive-join/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/external-payload/pom.xml
+++ b/examples/task-patterns/external-payload/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/fan-out-fan-in/pom.xml
+++ b/examples/task-patterns/fan-out-fan-in/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/fork-in-do-while/pom.xml
+++ b/examples/task-patterns/fork-in-do-while/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/fork-join/pom.xml
+++ b/examples/task-patterns/fork-join/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/graphql-api/pom.xml
+++ b/examples/task-patterns/graphql-api/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/idempotent-start/pom.xml
+++ b/examples/task-patterns/idempotent-start/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/inline-tasks/pom.xml
+++ b/examples/task-patterns/inline-tasks/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/jq-transform-advanced/pom.xml
+++ b/examples/task-patterns/jq-transform-advanced/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/nested-sub-workflows/pom.xml
+++ b/examples/task-patterns/nested-sub-workflows/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/nested-switch/pom.xml
+++ b/examples/task-patterns/nested-switch/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/passing-output-to-input/pom.xml
+++ b/examples/task-patterns/passing-output-to-input/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/rate-limiting/pom.xml
+++ b/examples/task-patterns/rate-limiting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/sequential-tasks/pom.xml
+++ b/examples/task-patterns/sequential-tasks/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/set-variable/pom.xml
+++ b/examples/task-patterns/set-variable/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/signals/pom.xml
+++ b/examples/task-patterns/signals/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/simple-plus-system/pom.xml
+++ b/examples/task-patterns/simple-plus-system/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/sub-workflows/pom.xml
+++ b/examples/task-patterns/sub-workflows/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/switch-default-case/pom.xml
+++ b/examples/task-patterns/switch-default-case/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/switch-javascript/pom.xml
+++ b/examples/task-patterns/switch-javascript/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/switch-plus-fork/pom.xml
+++ b/examples/task-patterns/switch-plus-fork/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/switch-task/pom.xml
+++ b/examples/task-patterns/switch-task/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/sync-execution/pom.xml
+++ b/examples/task-patterns/sync-execution/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/system-tasks/pom.xml
+++ b/examples/task-patterns/system-tasks/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/task-definitions/pom.xml
+++ b/examples/task-patterns/task-definitions/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/task-domains/pom.xml
+++ b/examples/task-patterns/task-domains/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/task-input-templates/pom.xml
+++ b/examples/task-patterns/task-input-templates/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/terminate-task/pom.xml
+++ b/examples/task-patterns/terminate-task/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/wait-for-event/pom.xml
+++ b/examples/task-patterns/wait-for-event/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/workflow-archival/pom.xml
+++ b/examples/task-patterns/workflow-archival/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/workflow-metadata/pom.xml
+++ b/examples/task-patterns/workflow-metadata/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/workflow-variables/pom.xml
+++ b/examples/task-patterns/workflow-variables/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/task-patterns/workflow-versioning/pom.xml
+++ b/examples/task-patterns/workflow-versioning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/billing-telecom/pom.xml
+++ b/examples/telecom/billing-telecom/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/capacity-mgmt-telecom/pom.xml
+++ b/examples/telecom/capacity-mgmt-telecom/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/customer-churn/pom.xml
+++ b/examples/telecom/customer-churn/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/network-monitoring/pom.xml
+++ b/examples/telecom/network-monitoring/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/number-porting/pom.xml
+++ b/examples/telecom/number-porting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/roaming-management/pom.xml
+++ b/examples/telecom/roaming-management/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/service-activation/pom.xml
+++ b/examples/telecom/service-activation/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/telecom-provisioning/pom.xml
+++ b/examples/telecom/telecom-provisioning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/trouble-ticket/pom.xml
+++ b/examples/telecom/trouble-ticket/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/telecom/usage-analytics/pom.xml
+++ b/examples/telecom/usage-analytics/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/car-rental/pom.xml
+++ b/examples/travel/car-rental/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/expense-reporting/pom.xml
+++ b/examples/travel/expense-reporting/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/hotel-booking/pom.xml
+++ b/examples/travel/hotel-booking/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/itinerary-planning/pom.xml
+++ b/examples/travel/itinerary-planning/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/reimbursement/pom.xml
+++ b/examples/travel/reimbursement/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/travel-analytics/pom.xml
+++ b/examples/travel/travel-analytics/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/travel-approval/pom.xml
+++ b/examples/travel/travel-approval/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/travel-booking/pom.xml
+++ b/examples/travel/travel-booking/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/travel-policy/pom.xml
+++ b/examples/travel/travel-policy/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/travel/visa-processing/pom.xml
+++ b/examples/travel/visa-processing/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/user-mgmt/account-deletion/pom.xml
+++ b/examples/user-mgmt/account-deletion/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/bulk-user-import/pom.xml
+++ b/examples/user-mgmt/bulk-user-import/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/data-export-request/pom.xml
+++ b/examples/user-mgmt/data-export-request/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/user-mgmt/email-verification/pom.xml
+++ b/examples/user-mgmt/email-verification/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/user-mgmt/gdpr-consent/pom.xml
+++ b/examples/user-mgmt/gdpr-consent/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/user-mgmt/multi-factor-auth/pom.xml
+++ b/examples/user-mgmt/multi-factor-auth/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/notification-preferences/pom.xml
+++ b/examples/user-mgmt/notification-preferences/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/user-mgmt/nps-scoring/pom.xml
+++ b/examples/user-mgmt/nps-scoring/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/password-reset/pom.xml
+++ b/examples/user-mgmt/password-reset/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/user-mgmt/permission-sync/pom.xml
+++ b/examples/user-mgmt/permission-sync/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/profile-update/pom.xml
+++ b/examples/user-mgmt/profile-update/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/user-mgmt/role-management/pom.xml
+++ b/examples/user-mgmt/role-management/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/session-management/pom.xml
+++ b/examples/user-mgmt/session-management/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/social-login/pom.xml
+++ b/examples/user-mgmt/social-login/pom.xml
@@ -17,7 +17,12 @@
 
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/user-analytics/pom.xml
+++ b/examples/user-mgmt/user-analytics/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/user-feedback/pom.xml
+++ b/examples/user-mgmt/user-feedback/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/user-migration/pom.xml
+++ b/examples/user-mgmt/user-migration/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>

--- a/examples/user-mgmt/user-onboarding/pom.xml
+++ b/examples/user-mgmt/user-onboarding/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/user-mgmt/user-registration/pom.xml
+++ b/examples/user-mgmt/user-registration/pom.xml
@@ -24,7 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.18.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/user-mgmt/user-survey/pom.xml
+++ b/examples/user-mgmt/user-survey/pom.xml
@@ -14,7 +14,12 @@
     </properties>
     <dependencies>
         <dependency><groupId>org.conductoross</groupId><artifactId>conductor-client</artifactId><version>5.0.1</version></dependency>
-        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.17.1</version></dependency>
+        <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId><version>2.18.6</version></dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.6</version>
+        </dependency>
         <dependency><groupId>org.slf4j</groupId><artifactId>slf4j-simple</artifactId><version>1.7.36</version></dependency>
         <dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter</artifactId><version>5.11.3</version><scope>test</scope></dependency>
     </dependencies>


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----
Reviewed output of full osv scan and applied suggested version updates.
- [Ran full OSV scan via PR with intentional failure](https://github.com/conductor-oss/java-sdk/actions/runs/25686261694)
- [Corrected the failure and re-ran](https://github.com/conductor-oss/java-sdk/actions/runs/25686449532)
- removed scan args from osv scans which was excluding the examples directory