### PR TITLE
Fix broken example

### DIFF
--- a/examples/resilience/saga-pattern/src/main/java/sagapattern/workers/ChargePaymentWorker.java
+++ b/examples/resilience/saga-pattern/src/main/java/sagapattern/workers/ChargePaymentWorker.java
@@ -7,8 +7,8 @@ import com.netflix.conductor.common.metadata.tasks.TaskResult;
 import java.time.Instant;
 
 /**
- * Charges payment for the trip. If shouldFail is true, returns a
- * FAILED_WITH_TERMINAL_ERROR to trigger saga compensation.
+ * Charges payment for the trip. If shouldFail is true, completes with
+ * output status "failed" so the SWITCH task can route to compensation.
  *
  * Input:
  *   - tripId (String, required): trip identifier
@@ -68,8 +68,7 @@ public class ChargePaymentWorker implements Worker {
 
         if (shouldFail) {
             System.out.println("  [charge_payment] Payment FAILED for trip " + tripId);
-            result.setStatus(TaskResult.Status.FAILED_WITH_TERMINAL_ERROR);
-            result.setReasonForIncompletion("Payment processing failed for trip " + tripId);
+            result.setStatus(TaskResult.Status.COMPLETED);
             result.getOutputData().put("status", "failed");
             return result;
         }


### PR DESCRIPTION
Pull Request type

----

- [x] Bugfix

Changes in this PR

----

While trying out a few of the recently added examples, I encountered a problem with one. We may want to do a full audit and run all of these to verify that they all work as expected.

The fix for this one: Change ChargePaymentWorker to return COMPLETED with output {"status": "failed"} instead of FAILED_WITH_TERMINAL_ERROR, so the workflow reaches the SWITCH and executes the compensation branch.

---

Before:

```bash
--- Scenario 1: Successful trip booking ---
  Workflow ID: 11ac697e-979b-4fb5-bc70-d0e3b93efe10
  [reserve_hotel] Reserving hotel for trip TRIP-001 -- reservationId=HTL-TRIP-001
  [book_flight] Booking flight for trip TRIP-001 -- bookingId=FLT-TRIP-001
  [charge_payment] Payment succeeded for trip TRIP-001 -- transactionId=TXN-TRIP-001
  Status: COMPLETED
  Output: {flight=FLT-TRIP-001, hotel=HTL-TRIP-001, tripId=TRIP-001, payment=success, transactionId=TXN-TRIP-001}
  As expected: trip booked successfully with all services confirmed.

--- Scenario 2: Payment failure triggers saga rollback ---
  Workflow ID: 9c8b3b86-1ba2-480d-950f-1a90aebffcca
  [reserve_hotel] Reserving hotel for trip TRIP-002 -- reservationId=HTL-TRIP-002
  [book_flight] Booking flight for trip TRIP-002 -- bookingId=FLT-TRIP-002
  [charge_payment] Payment FAILED for trip TRIP-002
  Status: FAILED
  Output: {flight=FLT-TRIP-002, hotel=HTL-TRIP-002, tripId=TRIP-002, payment=failed, transactionId=null}
  UNEXPECTED -- expected COMPLETED with status=ROLLED_BACK

Key insight: The saga pattern uses orchestrated compensation --
when a step fails, the workflow runs compensating tasks in reverse order
to undo the effects of previously completed steps.

Result: FAILED
```

_Describe the new behavior from this PR, and why it's needed_

The saga-pattern example exists to demonstrate orchestrated compensation: when payment fails, the workflow should run cancel_flight and cancel_hotel to undo previous steps. But ChargePaymentWorker returned FAILED_WITH_TERMINAL_ERROR on the failure path, which told Conductor the task itself crashed — failing the workflow immediately before reaching the SWITCH that routes to compensation. The compensation branch was dead code; Scenario 2 always ended with workflow status FAILED.

Fix: return COMPLETED with output {"status": "failed"} so the workflow continues to the SWITCH, which inspects the output and routes to the compensation tasks as designed.

The compensation path could never have executed — FAILED_WITH_TERMINAL_ERROR unconditionally short-circuits the workflow before reaching the SWITCH. This was present since the example was first added.

After fix:

```bash
--- Scenario 1: Successful trip booking ---
  Workflow ID: 5b0df9c1-95df-4b7b-84d6-b60a782499e2
  [reserve_hotel] Reserving hotel for trip TRIP-001 -- reservationId=HTL-TRIP-001
  [book_flight] Booking flight for trip TRIP-001 -- bookingId=FLT-TRIP-001
  [charge_payment] Payment succeeded for trip TRIP-001 -- transactionId=TXN-TRIP-001
  Status: COMPLETED
  Output: {flight=FLT-TRIP-001, hotel=HTL-TRIP-001, tripId=TRIP-001, payment=success, transactionId=TXN-TRIP-001}
  As expected: trip booked successfully with all services confirmed.

--- Scenario 2: Payment failure triggers saga rollback ---
  Workflow ID: 126e6893-7525-4a90-83bc-382771dcad2a
  [reserve_hotel] Reserving hotel for trip TRIP-002 -- reservationId=HTL-TRIP-002
  [book_flight] Booking flight for trip TRIP-002 -- bookingId=FLT-TRIP-002
  [charge_payment] Payment FAILED for trip TRIP-002
  [cancel_flight] Cancelling flight FLT-TRIP-002 for trip TRIP-002 (compensation) -- removed=true
  [cancel_hotel] Cancelling hotel HTL-TRIP-002 for trip TRIP-002 (compensation) -- removed=true
  Status: COMPLETED
  Output: {tripId=TRIP-002, status=ROLLED_BACK}
  As expected: payment failed, saga compensated by cancelling flight and hotel.

Key insight: The saga pattern uses orchestrated compensation --
when a step fails, the workflow runs compensating tasks in reverse order
to undo the effects of previously completed steps.

Result: PASSED
```