### PR TITLE
refresh auth token automatically when it expires

### DIFF
--- a/.github/workflows/harness-image.yml
+++ b/.github/workflows/harness-image.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    outputs:
+      cleaned-branch-name: ${{ steps.vars.outputs.cleaned-branch-name }}
     permissions:
       contents: read
       packages: write
@@ -89,4 +91,4 @@ jobs:
           repository: conductor-oss/oss-ci-util
           event-type: sdk_release
           client-payload: |-
-            {"tag": "${{ github.event.release.tag_name || 'latest' }}", "repo": "${{ github.repository }}"}
+            {"tag": "${{ github.event.release.tag_name || format('{0}-latest', needs.build-and-push.outputs.cleaned-branch-name) }}", "repo": "${{ github.repository }}"}

--- a/conductor-client/build.gradle
+++ b/conductor-client/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${versions.junit}"
 
     testImplementation 'org.mockito:mockito-core:5.12.0'
+    testImplementation "com.squareup.okhttp3:mockwebserver:${versions.okHttp}"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
     testImplementation 'org.codehaus.groovy:groovy:3.0.25'
     testImplementation 'ch.qos.logback:logback-classic:1.5.32'

--- a/conductor-client/src/main/java/io/orkes/conductor/client/ApiClient.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/ApiClient.java
@@ -30,6 +30,7 @@ import io.orkes.conductor.client.http.ApiCallback;
 import io.orkes.conductor.client.http.ApiResponse;
 import io.orkes.conductor.client.http.OrkesAuthentication;
 import io.orkes.conductor.client.http.Pair;
+import io.orkes.conductor.client.http.TokenRefreshAuthenticator;
 
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Call;
@@ -193,6 +194,7 @@ public final class ApiClient extends ConductorClient {
 
             this.authentication = new OrkesAuthentication(key, secret);
             this.addHeaderSupplier(this.authentication);
+            this.configureOkHttp(b -> b.authenticator(new TokenRefreshAuthenticator(this.authentication)));
             return this;
         }
 

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/OrkesAuthentication.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/OrkesAuthentication.java
@@ -15,11 +15,8 @@ package io.orkes.conductor.client.http;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,16 +34,12 @@ public class OrkesAuthentication implements HeaderSupplier {
     public static final String PROP_TOKEN_REFRESH_INTERVAL = "CONDUCTOR_SECURITY_TOKEN_REFRESH_INTERVAL";
     private static final Logger LOGGER = LoggerFactory.getLogger(OrkesAuthentication.class);
     private static final String TOKEN_CACHE_KEY = "TOKEN";
-    private final ScheduledExecutorService tokenRefreshService = Executors.newSingleThreadScheduledExecutor(
-            new BasicThreadFactory.Builder()
-                    .namingPattern("OrkesAuthenticationSupplier Token Refresh %d")
-                    .daemon(true)
-                    .build());
 
     private final Cache<String, String> tokenCache;
     private final String keyId;
     private final String keySecret;
     private final long tokenRefreshInSeconds;
+    private final Object refreshLock = new Object();
 
     private TokenResource tokenResource;
 
@@ -85,7 +78,6 @@ public class OrkesAuthentication implements HeaderSupplier {
     @Override
     public void init(ConductorClient client) {
         this.tokenResource = new TokenResource(client);
-        scheduleTokenRefresh();
         try {
             getToken();
         } catch (Throwable t) {
@@ -110,10 +102,24 @@ public class OrkesAuthentication implements HeaderSupplier {
         }
     }
 
-    private void scheduleTokenRefresh() {
-        long refreshInterval = Math.max(30, tokenRefreshInSeconds - 30); // why?
-        LOGGER.info("Starting token refresh thread to run at every {} seconds", refreshInterval);
-        tokenRefreshService.scheduleAtFixedRate(this::refreshToken, refreshInterval, refreshInterval, TimeUnit.SECONDS);
+    /**
+     * Force a token refresh, but only if the current cached token still matches the
+     * stale token that produced a 401. Prevents a thundering herd when many worker
+     * threads hit the expired token simultaneously.
+     *
+     * @param staleToken the token value that just produced a 401 response
+     * @return a fresh (or already-rotated) token
+     */
+    public String refreshIfStale(String staleToken) {
+        synchronized (refreshLock) {
+            String current = tokenCache.getIfPresent(TOKEN_CACHE_KEY);
+            if (current != null && !current.equals(staleToken)) {
+                return current; // another thread already rotated it
+            }
+            String fresh = refreshToken();
+            tokenCache.put(TOKEN_CACHE_KEY, fresh); // resets TTL and unblocks others
+            return fresh;
+        }
     }
 
     private String refreshToken() {

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/TokenRefreshAuthenticator.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/TokenRefreshAuthenticator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.orkes.conductor.client.http;
+
+import org.jetbrains.annotations.Nullable;
+
+import okhttp3.Authenticator;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+
+/**
+ * Reacts to a {@code 401 Unauthorized} (e.g. an expired token) by minting a
+ * fresh token and replaying the original request with it. OkHttp invokes this
+ * automatically whenever a response comes back as 401, for both synchronous and
+ * asynchronous calls.
+ */
+public final class TokenRefreshAuthenticator implements Authenticator {
+
+    private final OrkesAuthentication auth;
+
+    public TokenRefreshAuthenticator(OrkesAuthentication auth) {
+        this.auth = auth;
+    }
+
+    @Nullable
+    @Override
+    public Request authenticate(@Nullable Route route, Response response) {
+        // Never try to refresh on the token-mint endpoint itself.
+        if (response.request().url().encodedPath().endsWith("/token")) {
+            return null;
+        }
+        // Loop protection: at most one retry.
+        if (responseCount(response) >= 2) {
+            return null;
+        }
+
+        String stale = response.request().header("X-Authorization");
+        String fresh = auth.refreshIfStale(stale);
+        if (fresh == null || fresh.equals(stale)) {
+            return null;
+        }
+
+        return response.request().newBuilder()
+                .header("X-Authorization", fresh)
+                .build();
+    }
+
+    private int responseCount(Response response) {
+        int count = 1;
+        while ((response = response.priorResponse()) != null) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/conductor-client/src/test/java/io/orkes/conductor/client/http/TokenRefreshTest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/http/TokenRefreshTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,6 @@ import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.jetbrains.annotations.NotNull;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/http/TokenRefreshTest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/http/TokenRefreshTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.orkes.conductor.client.http;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.client.exception.ConductorClientException;
+import com.netflix.conductor.client.http.ConductorClientRequest;
+import com.netflix.conductor.client.http.ConductorClientRequest.Method;
+import com.netflix.conductor.client.http.ConductorClientResponse;
+
+import io.orkes.conductor.client.ApiClient;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Simulates a token expiring mid-use and verifies the client reactively refreshes
+ * the token on a 401 and retries the request. These tests fail if the
+ * {@link TokenRefreshAuthenticator} wiring is removed: without it the first 401
+ * propagates as a {@link ConductorClientException} instead of being retried.
+ */
+public class TokenRefreshTest {
+
+    private static final String AUTH_HEADER = "X-Authorization";
+    private static final TypeReference<String> STRING_TYPE = new TypeReference<>() {
+    };
+
+    private MockWebServer server;
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+
+    private ApiClient buildClient() {
+        return ApiClient.builder()
+                .basePath(server.url("/api").toString())
+                .credentials("test-key", "test-secret")
+                .build();
+    }
+
+    private ConductorClientResponse<String> callBusinessEndpoint(ApiClient client) {
+        return client.execute(
+                ConductorClientRequest.builder()
+                        .method(Method.GET)
+                        .path("/ping")
+                        .build(),
+                STRING_TYPE);
+    }
+
+    /**
+     * Dispatcher that mints incrementing tokens on /token, and treats the very first
+     * minted token as "expired" on the business endpoint (returns 401). Any other
+     * token is accepted (200).
+     */
+    private static class ExpiringTokenDispatcher extends Dispatcher {
+        final AtomicInteger tokenMints = new AtomicInteger(0);
+        final AtomicReference<String> firstToken = new AtomicReference<>();
+        final AtomicReference<String> lastAcceptedToken = new AtomicReference<>();
+        final boolean alwaysExpire;
+
+        ExpiringTokenDispatcher(boolean alwaysExpire) {
+            this.alwaysExpire = alwaysExpire;
+        }
+
+        @NotNull
+        @Override
+        public MockResponse dispatch(@NotNull RecordedRequest request) {
+            String path = request.getPath() == null ? "" : request.getPath();
+            if (path.endsWith("/token") && "POST".equals(request.getMethod())) {
+                String token = "token-" + tokenMints.incrementAndGet();
+                firstToken.compareAndSet(null, token);
+                return new MockResponse()
+                        .setResponseCode(200)
+                        .setHeader("Content-Type", "application/json")
+                        .setBody("{\"token\":\"" + token + "\"}");
+            }
+
+            String presented = request.getHeader(AUTH_HEADER);
+            boolean expired = alwaysExpire
+                    || (firstToken.get() != null && firstToken.get().equals(presented));
+            if (expired) {
+                return new MockResponse()
+                        .setResponseCode(401)
+                        .setHeader("Content-Type", "application/json")
+                        .setBody("{\"message\":\"EXPIRED_TOKEN\"}");
+            }
+
+            lastAcceptedToken.set(presented);
+            return new MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "text/plain")
+                    .setBody("ok");
+        }
+    }
+
+    @Test
+    public void refreshesAndContinuesAfterExpiry() throws IOException {
+        server = new MockWebServer();
+        ExpiringTokenDispatcher dispatcher = new ExpiringTokenDispatcher(false);
+        server.setDispatcher(dispatcher);
+        server.start();
+
+        ApiClient client = buildClient();
+
+        ConductorClientResponse<String> response = callBusinessEndpoint(client);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("ok", response.getData());
+        // One mint at init (token-1) plus one reactive refresh after the 401 (token-2).
+        assertEquals(2, dispatcher.tokenMints.get());
+        // The successful (retried) request must have carried the refreshed token.
+        assertEquals("token-2", dispatcher.lastAcceptedToken.get());
+    }
+
+    @Test
+    public void continuesUsingCachedTokenAfterRefresh() throws IOException {
+        server = new MockWebServer();
+        ExpiringTokenDispatcher dispatcher = new ExpiringTokenDispatcher(false);
+        server.setDispatcher(dispatcher);
+        server.start();
+
+        ApiClient client = buildClient();
+
+        // First call triggers the refresh (token-1 -> 401 -> token-2 -> 200).
+        ConductorClientResponse<String> first = callBusinessEndpoint(client);
+        assertEquals(200, first.getStatusCode());
+        assertEquals(2, dispatcher.tokenMints.get());
+
+        // Second call should reuse the cached token-2 with no additional mint.
+        ConductorClientResponse<String> second = callBusinessEndpoint(client);
+        assertEquals(200, second.getStatusCode());
+        assertEquals("ok", second.getData());
+        assertEquals(2, dispatcher.tokenMints.get(), "no extra token mint expected for cached token");
+        assertEquals("token-2", dispatcher.lastAcceptedToken.get());
+    }
+
+    @Test
+    public void loopProtectionGivesUpAfterOneRetry() throws IOException {
+        server = new MockWebServer();
+        ExpiringTokenDispatcher dispatcher = new ExpiringTokenDispatcher(true);
+        server.setDispatcher(dispatcher);
+        server.start();
+
+        ApiClient client = buildClient();
+
+        assertThrows(ConductorClientException.class, () -> callBusinessEndpoint(client));
+        // Init mint (token-1) plus exactly one reactive refresh attempt (token-2); then it gives up.
+        assertEquals(2, dispatcher.tokenMints.get(),
+                "authenticator must retry at most once and not loop");
+        assertTrue(dispatcher.tokenMints.get() <= 2);
+    }
+}


### PR DESCRIPTION
remove non-functioning scheduled refresh thing and replace with automatic refresh

Pull Request type
----
- [ x ] Bugfix

Changes in this PR
----
remove broken code that refreshed token and threw it away every 45 mins, in favor of keeping the actually-working expired-cache-entry re-establisher plus newly using okhttp auth hook to freshen it in response to 401.

Alternatives considered 
----

http interceptor but okhttp auth hook was deemed superior.
