### PR TITLE
add asyncComplete support to sdk Task base class

### DIFF
--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Event.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Event.java
@@ -22,6 +22,8 @@ public class Event extends Task<Event> {
 
     private static final String SINK_PARAMETER = "sink";
 
+    private boolean asyncComplete;
+
     /**
      * @param taskReferenceName Unique reference name within the workflow
      * @param eventSink qualified name of the event sink where the message is published. Using the
@@ -38,6 +40,21 @@ public class Event extends Task<Event> {
 
     Event(WorkflowTask workflowTask) {
         super(workflowTask);
+        this.asyncComplete = Boolean.TRUE.equals(workflowTask.isAsyncComplete());
+    }
+
+    public Event asyncComplete(boolean asyncComplete) {
+        this.asyncComplete = asyncComplete;
+        return this;
+    }
+
+    public boolean isAsyncComplete() {
+        return asyncComplete;
+    }
+
+    @Override
+    protected void updateWorkflowTask(WorkflowTask workflowTask) {
+        workflowTask.setAsyncComplete(asyncComplete);
     }
 
     public String getSink() {

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Http.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Http.java
@@ -34,6 +34,8 @@ public class Http extends Task<Http> {
 
     private final ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper();
 
+    private boolean asyncComplete;
+
     private Input httpRequest;
 
     public Http(String taskReferenceName) {
@@ -45,6 +47,7 @@ public class Http extends Task<Http> {
 
     Http(WorkflowTask workflowTask) {
         super(workflowTask);
+        this.asyncComplete = Boolean.TRUE.equals(workflowTask.isAsyncComplete());
 
         Object inputRequest = workflowTask.getInputParameters().get(INPUT_PARAM);
         if (inputRequest != null) {
@@ -54,6 +57,15 @@ public class Http extends Task<Http> {
                 LOGGER.error("Error while trying to convert input request " + e.getMessage(), e);
             }
         }
+    }
+
+    public Http asyncComplete(boolean asyncComplete) {
+        this.asyncComplete = asyncComplete;
+        return this;
+    }
+
+    public boolean isAsyncComplete() {
+        return asyncComplete;
     }
 
     public Http input(Input httpRequest) {
@@ -92,6 +104,7 @@ public class Http extends Task<Http> {
 
     @Override
     protected void updateWorkflowTask(WorkflowTask workflowTask) {
+        workflowTask.setAsyncComplete(asyncComplete);
         workflowTask.getInputParameters().put(INPUT_PARAM, httpRequest);
     }
 

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Task.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Task.java
@@ -39,8 +39,6 @@ public abstract class Task<T> {
 
     private int startDelay;
 
-    private boolean asyncComplete;
-
     private final TaskType type;
 
     private Map<String, Object> input = new HashMap<>();
@@ -71,7 +69,6 @@ public abstract class Task<T> {
         this.input = workflowTask.getInputParameters();
         this.description = workflowTask.getDescription();
         this.name = workflowTask.getName();
-        this.asyncComplete = Boolean.TRUE.equals(workflowTask.isAsyncComplete());
     }
 
     public T name(String name) {
@@ -82,15 +79,6 @@ public abstract class Task<T> {
     public T description(String description) {
         this.description = description;
         return (T) this;
-    }
-
-    public T asyncComplete(boolean asyncComplete) {
-        this.asyncComplete = asyncComplete;
-        return (T) this;
-    }
-
-    public boolean isAsyncComplete() {
-        return asyncComplete;
     }
 
     public T input(String key, boolean value) {
@@ -222,7 +210,6 @@ public abstract class Task<T> {
         workflowTask.setInputParameters(input);
         workflowTask.setStartDelay(startDelay);
         workflowTask.setOptional(optional);
-        workflowTask.setAsyncComplete(asyncComplete);
 
         // Let the sub-classes enrich the workflow task before returning back
         updateWorkflowTask(workflowTask);

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Task.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Task.java
@@ -39,6 +39,8 @@ public abstract class Task<T> {
 
     private int startDelay;
 
+    private boolean asyncComplete;
+
     private final TaskType type;
 
     private Map<String, Object> input = new HashMap<>();
@@ -69,6 +71,7 @@ public abstract class Task<T> {
         this.input = workflowTask.getInputParameters();
         this.description = workflowTask.getDescription();
         this.name = workflowTask.getName();
+        this.asyncComplete = Boolean.TRUE.equals(workflowTask.isAsyncComplete());
     }
 
     public T name(String name) {
@@ -79,6 +82,15 @@ public abstract class Task<T> {
     public T description(String description) {
         this.description = description;
         return (T) this;
+    }
+
+    public T asyncComplete(boolean asyncComplete) {
+        this.asyncComplete = asyncComplete;
+        return (T) this;
+    }
+
+    public boolean isAsyncComplete() {
+        return asyncComplete;
     }
 
     public T input(String key, boolean value) {
@@ -210,6 +222,7 @@ public abstract class Task<T> {
         workflowTask.setInputParameters(input);
         workflowTask.setStartDelay(startDelay);
         workflowTask.setOptional(optional);
+        workflowTask.setAsyncComplete(asyncComplete);
 
         // Let the sub-classes enrich the workflow task before returning back
         updateWorkflowTask(workflowTask);

--- a/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/def/TaskConversionsTests.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/def/TaskConversionsTests.java
@@ -461,6 +461,19 @@ public class TaskConversionsTests {
     }
 
     @Test
+    public void testHttpAsyncComplete() {
+        Http httpTask = new Http("http_ref");
+        httpTask.asyncComplete(true);
+
+        WorkflowTask workflowTask = httpTask.getWorkflowDefTasks().get(0);
+        assertTrue(workflowTask.isAsyncComplete());
+
+        Task fromWorkflowTask = TaskRegistry.getTask(workflowTask);
+        assertTrue(fromWorkflowTask instanceof Http);
+        assertTrue(((Http) fromWorkflowTask).isAsyncComplete());
+    }
+
+    @Test
     public void testJQTaskConversion() {
         JQ jqTask = new JQ("task_name", "{ key3: (.key1.value1 + .key2.value2) }");
 

--- a/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/def/TaskConversionsTests.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/def/TaskConversionsTests.java
@@ -474,6 +474,19 @@ public class TaskConversionsTests {
     }
 
     @Test
+    public void testEventAsyncComplete() {
+        Event eventTask = new Event("event_ref", "sqs:my-queue");
+        eventTask.asyncComplete(true);
+
+        WorkflowTask workflowTask = eventTask.getWorkflowDefTasks().get(0);
+        assertTrue(workflowTask.isAsyncComplete());
+
+        Task fromWorkflowTask = TaskRegistry.getTask(workflowTask);
+        assertTrue(fromWorkflowTask instanceof Event);
+        assertTrue(((Event) fromWorkflowTask).isAsyncComplete());
+    }
+
+    @Test
     public void testJQTaskConversion() {
         JQ jqTask = new JQ("task_name", "{ key3: (.key1.value1 + .key2.value2) }");
 


### PR DESCRIPTION
`asyncComplete` exists on `WorkflowTask` but is not exposed through the sdk, making it impossible to define async http or event tasks without subclassing as a workaround.

adds the field to `Task<T>` alongside `optional` and `startDelay`, wires it through `toWorkflowTask()` and restores it from the `WorkflowTask` constructor. any task type can now call `.asyncComplete(true)`.