### PR TITLE
Bump pinned conductor-oss e2e server version to 3.32.0-rc18

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -25,9 +25,6 @@ env:
 
 jobs:
   agent-e2e:
-    # Temporarily disabled until a Conductor server release containing the
-    # required agent-runtime changes is published.
-    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:

--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CONDUCTOR_SERVER_VERSION: "3.32.0-rc.8"   # pinned server release — bump deliberately
+  CONDUCTOR_SERVER_VERSION: "3.32.0-rc18"   # pinned server release — bump deliberately
 
 jobs:
   agent-e2e:


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- Bump `CONDUCTOR_SERVER_VERSION` in `.github/workflows/agent-e2e.yml` from `3.32.0-rc.8` to `3.32.0-rc18`.

Alternatives considered
----

_Describe alternative implementation you have considered_