### PR TITLE
Remove Codecov upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,13 +150,6 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           
-      - name: Upload coverage to Codecov
-        if: always()
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: '**/build/reports/jacoco/test/jacocoTestReport.xml'
-        
       - name: Check Tests Status
         if: steps.tests.outcome == 'failure'
         run: exit 1


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- remove the Codecov upload step from the build job
- jacoco report still generated, unaffected
- Publish Test Report check (mikepenz/action-junit-report) already covers pass/fail counts, unaffected

Alternatives considered
----

- silence just the PR comment and keep the upload — dropped, the App isn't installed so there's nothing else the upload does
