### PR TITLE
Resolve #132: HUMAN task: missing builder class

### DIFF
--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Human.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Human.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sdk.workflow.def.tasks;
+
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+
+/** Human task */
+public class Human extends Task<Human> {
+
+    public Human(String taskReferenceName) {
+        super(taskReferenceName, TaskType.HUMAN);
+    }
+}

--- a/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/def/WorkflowDefTaskTests.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/def/WorkflowDefTaskTests.java
@@ -14,7 +14,9 @@ package com.netflix.conductor.sdk.workflow.def;
 
 import org.junit.jupiter.api.Test;
 
+import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.sdk.workflow.def.tasks.Human;
 import com.netflix.conductor.sdk.workflow.def.tasks.SimpleTask;
 import com.netflix.conductor.sdk.workflow.executor.WorkflowExecutor;
 
@@ -24,6 +26,16 @@ public class WorkflowDefTaskTests {
 
     static {
         WorkflowExecutor.initTaskImplementations();
+    }
+
+    @Test
+    public void testHumanTask() {
+        String taskReferenceName = "human_approval_ref";
+
+        WorkflowTask workflowTask = new Human(taskReferenceName).getWorkflowDefTasks().get(0);
+
+        assertEquals(TaskType.HUMAN.name(), workflowTask.getType());
+        assertEquals(taskReferenceName, workflowTask.getTaskReferenceName());
     }
 
     @Test


### PR DESCRIPTION
Closes #132

## Summary
Add the missing fluent HUMAN task builder and a focused unit test confirming it produces a HUMAN WorkflowTask with the requested reference name. No registry conversion or input-parameter override is needed because the issue explicitly scopes the fix to builder creation.