### PR TITLE
Resolve #133: ExclusiveJoin builder class for EXCLUSIVE_JOIN task type

### DIFF
--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/ExclusiveJoin.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/ExclusiveJoin.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sdk.workflow.def.tasks;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+
+public class ExclusiveJoin extends Task<ExclusiveJoin> {
+
+    private final String[] joinOn;
+
+    private String[] defaultExclusiveJoinTask = new String[0];
+
+    /**
+     * @param taskReferenceName task reference name
+     * @param joinOn list of task reference names to join on
+     */
+    public ExclusiveJoin(String taskReferenceName, String... joinOn) {
+        super(taskReferenceName, TaskType.EXCLUSIVE_JOIN);
+        this.joinOn = joinOn;
+    }
+
+    ExclusiveJoin(WorkflowTask workflowTask) {
+        super(workflowTask);
+        this.joinOn = workflowTask.getJoinOn().toArray(new String[0]);
+        List<String> defaults = workflowTask.getDefaultExclusiveJoinTask();
+        this.defaultExclusiveJoinTask = defaults.toArray(new String[0]);
+    }
+
+    public ExclusiveJoin defaultExclusiveJoinTask(String... tasks) {
+        this.defaultExclusiveJoinTask = tasks;
+        return this;
+    }
+
+    @Override
+    protected void updateWorkflowTask(WorkflowTask workflowTask) {
+        workflowTask.setJoinOn(Arrays.asList(joinOn));
+        workflowTask.setDefaultExclusiveJoinTask(Arrays.asList(defaultExclusiveJoinTask));
+    }
+
+    public String[] getJoinOn() {
+        return joinOn;
+    }
+
+    public String[] getDefaultExclusiveJoinTask() {
+        return defaultExclusiveJoinTask;
+    }
+}

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
@@ -50,6 +50,7 @@ import com.netflix.conductor.sdk.workflow.def.tasks.DoWhile;
 import com.netflix.conductor.sdk.workflow.def.tasks.Dynamic;
 import com.netflix.conductor.sdk.workflow.def.tasks.DynamicFork;
 import com.netflix.conductor.sdk.workflow.def.tasks.Event;
+import com.netflix.conductor.sdk.workflow.def.tasks.ExclusiveJoin;
 import com.netflix.conductor.sdk.workflow.def.tasks.ForkJoin;
 import com.netflix.conductor.sdk.workflow.def.tasks.Http;
 import com.netflix.conductor.sdk.workflow.def.tasks.JQ;
@@ -107,6 +108,7 @@ public class WorkflowExecutor {
         TaskRegistry.register(TaskType.FORK_JOIN.name(), ForkJoin.class);
         TaskRegistry.register(TaskType.HTTP.name(), Http.class);
         TaskRegistry.register(TaskType.INLINE.name(), Javascript.class);
+        TaskRegistry.register(TaskType.EXCLUSIVE_JOIN.name(), ExclusiveJoin.class);
         TaskRegistry.register(TaskType.JOIN.name(), Join.class);
         TaskRegistry.register(TaskType.JSON_JQ_TRANSFORM.name(), JQ.class);
         TaskRegistry.register(TaskType.SET_VARIABLE.name(), SetVariable.class);

--- a/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/def/TaskConversionsTests.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/def/TaskConversionsTests.java
@@ -28,6 +28,7 @@ import com.netflix.conductor.sdk.workflow.def.tasks.DoWhile;
 import com.netflix.conductor.sdk.workflow.def.tasks.Dynamic;
 import com.netflix.conductor.sdk.workflow.def.tasks.DynamicFork;
 import com.netflix.conductor.sdk.workflow.def.tasks.Event;
+import com.netflix.conductor.sdk.workflow.def.tasks.ExclusiveJoin;
 import com.netflix.conductor.sdk.workflow.def.tasks.ForkJoin;
 import com.netflix.conductor.sdk.workflow.def.tasks.Http;
 import com.netflix.conductor.sdk.workflow.def.tasks.JQ;
@@ -543,6 +544,51 @@ public class TaskConversionsTests {
                 "function e() { if ($.value == 1){return {\"result\": true}} else { return {\"result\": false}}} e();");
         var result = inlineTask.validate();
         assertNotNull(result);
+    }
+
+    @Test
+    public void testExclusiveJoin() {
+        ExclusiveJoin exclusiveJoin =
+                new ExclusiveJoin("task_ref_name", "task1", "task2")
+                        .defaultExclusiveJoinTask("task_default");
+
+        WorkflowTask workflowTask = exclusiveJoin.getWorkflowDefTasks().get(0);
+        assertNotNull(workflowTask.getJoinOn());
+        assertFalse(workflowTask.getJoinOn().isEmpty());
+        assertNotNull(workflowTask.getDefaultExclusiveJoinTask());
+        assertFalse(workflowTask.getDefaultExclusiveJoinTask().isEmpty());
+
+        Task fromWorkflowTask = TaskRegistry.getTask(workflowTask);
+        assertTrue(
+                fromWorkflowTask instanceof ExclusiveJoin,
+                "task is not of type ExclusiveJoin, but of type "
+                        + fromWorkflowTask.getClass().getName());
+        ExclusiveJoin taskFromWorkflowTask = (ExclusiveJoin) fromWorkflowTask;
+
+        assertNotNull(fromWorkflowTask);
+        assertEquals(exclusiveJoin.getName(), fromWorkflowTask.getName());
+        assertEquals(exclusiveJoin.getTaskReferenceName(), fromWorkflowTask.getTaskReferenceName());
+        assertEquals(exclusiveJoin.getType(), taskFromWorkflowTask.getType());
+
+        assertEquals(exclusiveJoin.getJoinOn().length, taskFromWorkflowTask.getJoinOn().length);
+        assertEquals(
+                Arrays.asList(exclusiveJoin.getJoinOn()).stream()
+                        .sorted()
+                        .collect(Collectors.toSet()),
+                Arrays.asList(taskFromWorkflowTask.getJoinOn()).stream()
+                        .sorted()
+                        .collect(Collectors.toSet()));
+
+        assertEquals(
+                exclusiveJoin.getDefaultExclusiveJoinTask().length,
+                taskFromWorkflowTask.getDefaultExclusiveJoinTask().length);
+        assertEquals(
+                Arrays.asList(exclusiveJoin.getDefaultExclusiveJoinTask()).stream()
+                        .sorted()
+                        .collect(Collectors.toSet()),
+                Arrays.asList(taskFromWorkflowTask.getDefaultExclusiveJoinTask()).stream()
+                        .sorted()
+                        .collect(Collectors.toSet()));
     }
 
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

`TaskType.EXCLUSIVE_JOIN` existed in the enum but there was no builder class, making `WorkflowTask.defaultExclusiveJoinTask` unreachable through the SDK fluent API.

This adds `ExclusiveJoin`, which follows the same pattern as `Join`. The constructor accepts a `taskReferenceName` and a varargs `joinOn` list. A `defaultExclusiveJoinTask(String... tasks)` fluent method sets the fallback reference names used when no SWITCH branch matches. `WorkflowExecutor.initTaskImplementations` now registers `EXCLUSIVE_JOIN -> ExclusiveJoin.class` so `TaskRegistry.getTask` can reconstruct it from a `WorkflowTask`. A round-trip conversion test is added to `TaskConversionsTests`.

Issue #133

Alternatives considered
----

Could have reused `Join` with an extra optional field, but a separate class keeps the API surface consistent with every other task type in the package and avoids changing an existing stable class.

Signed-off-by: klouds27 <adalwolf@gmail.com>