### PR TITLE
CCOR-13193 - run integration tests against Conductor OSS, and fix two client bugs it surfaced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   documentation-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,10 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      oss_conductor_version:
-        description: 'OSS Conductor image tag (falls back to E2E_TEST_OSS_CONDUCTOR_VERSION org var)'
-        required: false
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
-  checks: write
 
 jobs:
   documentation-validation:
@@ -158,68 +149,13 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          # Distinct per suite: the default is 'JUnit Test Report' for every caller, so this
-          # report, the OSS one below, and the one in integration-tests.yml all landed on a
-          # single check run and overwrote each other.
+          # Distinct per suite: the action defaults to 'JUnit Test Report' for every caller, so
+          # this report and the ones published by integration-tests.yml all landed on a single
+          # check run and overwrote each other.
           check_name: Unit Test Report
 
       - name: Check Tests Status
         if: steps.tests.outcome == 'failure'
         run: |
           echo "::error::Tests failed. See the 'Run Tests' step above for the Gradle/test output, and the 'Publish Test Report' step's JUnit summary for which test(s) failed."
-          exit 1
-
-  integration-tests-oss:
-    runs-on: ubuntu-latest
-    name: Integration Tests (OSS)
-    timeout-minutes: 30
-    env:
-      CONDUCTOR_SERVER_URL: http://localhost:8080/api
-      CONDUCTOR_SERVER_TYPE: oss
-      OSS_CONDUCTOR_VERSION: ${{ inputs.oss_conductor_version || vars.E2E_TEST_OSS_CONDUCTOR_VERSION }}
-
-    steps:
-      - name: Verify OSS Conductor version is set
-        run: |
-          if [ -z "$OSS_CONDUCTOR_VERSION" ]; then
-            echo "::error::No Conductor OSS image tag resolved. Set the E2E_TEST_OSS_CONDUCTOR_VERSION organization variable (and ensure its repository access policy includes this repo), or pass the oss_conductor_version input via workflow_dispatch."
-            exit 1
-          fi
-          echo "Using conductoross/conductor:$OSS_CONDUCTOR_VERSION"
-
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Zulu JDK 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: "zulu"
-          java-version: "21"
-
-      - name: Start Conductor OSS stack
-        run: docker compose -f scripts/docker-compose-oss.yaml up -d
-
-      - name: Wait for Conductor to be healthy
-        run: timeout 120 bash -c 'until curl -sf http://localhost:8080/health; do sleep 5; done'
-
-      - name: Run integration tests (OSS)
-        id: integration_tests
-        continue-on-error: true
-        run: ./gradlew :tests:test -PIntegrationTests
-
-      - name: Dump Conductor logs
-        if: failure() || steps.integration_tests.outcome == 'failure'
-        run: docker compose -f scripts/docker-compose-oss.yaml logs conductor-server
-
-      - name: Publish Test Report
-        if: always()
-        uses: mikepenz/action-junit-report@v6
-        with:
-          report_paths: '**/tests/build/test-results/test/TEST-*.xml'
-          check_name: OSS Integration Test Report
-
-      - name: Check Integration Tests Status
-        if: steps.integration_tests.outcome == 'failure'
-        run: |
-          echo "::error::Integration tests (OSS) failed. See the 'Run integration tests (OSS)' step above for the Gradle/test output, the 'Dump Conductor logs' step for server-side logs, and the 'Publish Test Report' step's JUnit summary for which test(s) failed."
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,9 @@ jobs:
           
       - name: Check Tests Status
         if: steps.tests.outcome == 'failure'
-        run: exit 1
+        run: |
+          echo "::error::Tests failed. See the 'Run Tests' step above for the Gradle/test output, and the 'Publish Test Report' step's JUnit summary for which test(s) failed."
+          exit 1
 
   integration-tests-oss:
     runs-on: ubuntu-latest
@@ -213,4 +215,6 @@ jobs:
 
       - name: Check Integration Tests Status
         if: steps.integration_tests.outcome == 'failure'
-        run: exit 1
+        run: |
+          echo "::error::Integration tests (OSS) failed. See the 'Run integration tests (OSS)' step above for the Gradle/test output, the 'Dump Conductor logs' step for server-side logs, and the 'Publish Test Report' step's JUnit summary for which test(s) failed."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,11 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          
+          # Distinct per suite: the default is 'JUnit Test Report' for every caller, so this
+          # report, the OSS one below, and the one in integration-tests.yml all landed on a
+          # single check run and overwrote each other.
+          check_name: Unit Test Report
+
       - name: Check Tests Status
         if: steps.tests.outcome == 'failure'
         run: |
@@ -212,6 +216,7 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         with:
           report_paths: '**/tests/build/test-results/test/TEST-*.xml'
+          check_name: OSS Integration Test Report
 
       - name: Check Integration Tests Status
         if: steps.integration_tests.outcome == 'failure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      oss_conductor_version:
+        description: 'OSS Conductor image tag (falls back to E2E_TEST_OSS_CONDUCTOR_VERSION org var)'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -152,4 +157,56 @@ jobs:
           
       - name: Check Tests Status
         if: steps.tests.outcome == 'failure'
+        run: exit 1
+
+  integration-tests-oss:
+    runs-on: ubuntu-latest
+    name: Integration Tests (OSS)
+    timeout-minutes: 30
+    env:
+      CONDUCTOR_SERVER_URL: http://localhost:8080/api
+      CONDUCTOR_SERVER_TYPE: oss
+      OSS_CONDUCTOR_VERSION: ${{ inputs.oss_conductor_version || vars.E2E_TEST_OSS_CONDUCTOR_VERSION }}
+
+    steps:
+      - name: Verify OSS Conductor version is set
+        run: |
+          if [ -z "$OSS_CONDUCTOR_VERSION" ]; then
+            echo "::error::No Conductor OSS image tag resolved. Set the E2E_TEST_OSS_CONDUCTOR_VERSION organization variable (and ensure its repository access policy includes this repo), or pass the oss_conductor_version input via workflow_dispatch."
+            exit 1
+          fi
+          echo "Using conductoross/conductor:$OSS_CONDUCTOR_VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Zulu JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "21"
+
+      - name: Start Conductor OSS stack
+        run: docker compose -f scripts/docker-compose-oss.yaml up -d
+
+      - name: Wait for Conductor to be healthy
+        run: timeout 120 bash -c 'until curl -sf http://localhost:8080/health; do sleep 5; done'
+
+      - name: Run integration tests (OSS)
+        id: integration_tests
+        continue-on-error: true
+        run: ./gradlew :tests:test -PIntegrationTests
+
+      - name: Dump Conductor logs
+        if: failure() || steps.integration_tests.outcome == 'failure'
+        run: docker compose -f scripts/docker-compose-oss.yaml logs conductor-server
+
+      - name: Publish Test Report
+        if: always()
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: '**/tests/build/test-results/test/TEST-*.xml'
+
+      - name: Check Integration Tests Status
+        if: steps.integration_tests.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,12 @@ on:
     workflows: ["Java Client Build"]
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      oss_conductor_version:
+        description: 'OSS Conductor image tag (falls back to E2E_TEST_OSS_CONDUCTOR_VERSION org var)'
+        required: false
+        type: string
 
 # allow this workflow to update the status of the PR that triggered it
 permissions:
@@ -44,7 +50,11 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          
+          # Distinct per suite: the action defaults to 'JUnit Test Report' for every caller, so
+          # this report, the OSS one below, and ci.yml's unit report all landed on a single
+          # check run and overwrote each other.
+          check_name: Integration Test Report
+
       - name: Update PR Status
         if: always()
         uses: actions/github-script@v8
@@ -60,4 +70,88 @@ jobs:
               description: 'Integration tests ${{ job.status }}'
             });
 
+  # Runs against a throwaway Conductor OSS stack rather than the Orkes deployment the job above
+  # targets, so it needs no secrets and no `environment`. It is deliberately a sibling of that
+  # job, not a dependent: an OSS failure must not suppress the enterprise suite, or vice versa.
+  integration-tests-oss:
+    runs-on: ubuntu-latest
+    name: Integration Tests (OSS)
+    timeout-minutes: 30
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    env:
+      CONDUCTOR_SERVER_URL: http://localhost:8080/api
+      CONDUCTOR_SERVER_TYPE: oss
+      OSS_CONDUCTOR_VERSION: ${{ inputs.oss_conductor_version || vars.E2E_TEST_OSS_CONDUCTOR_VERSION }}
+
+    steps:
+      - name: Verify OSS Conductor version is set
+        run: |
+          if [ -z "$OSS_CONDUCTOR_VERSION" ]; then
+            echo "::error::No Conductor OSS image tag resolved. Set the E2E_TEST_OSS_CONDUCTOR_VERSION organization variable (and ensure its repository access policy includes this repo), or pass the oss_conductor_version input via workflow_dispatch."
+            exit 1
+          fi
+          echo "Using conductoross/conductor:$OSS_CONDUCTOR_VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # workflow_run carries the triggering run's head; workflow_dispatch has neither, and
+          # falls back to the ref the dispatch was made against.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          repository: ${{ github.event.workflow_run.repository.full_name || github.repository }}
+
+      - name: Set up Zulu JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "21"
+
+      - name: Start Conductor OSS stack
+        run: docker compose -f scripts/docker-compose-oss.yaml up -d
+
+      - name: Wait for Conductor to be healthy
+        # Matches HEALTH_TIMEOUT in scripts/run-integration-oss.sh, and stays under the compose
+        # healthcheck's own ~200s budget.
+        run: timeout 180 bash -c 'until curl -sf http://localhost:8080/health; do sleep 5; done'
+
+      - name: Run integration tests (OSS)
+        id: integration_tests
+        continue-on-error: true
+        run: ./gradlew :tests:test -PIntegrationTests
+
+      - name: Dump Conductor logs
+        if: failure() || steps.integration_tests.outcome == 'failure'
+        run: docker compose -f scripts/docker-compose-oss.yaml logs conductor-server
+
+      - name: Publish Test Report
+        if: always()
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: 'tests/build/test-results/test/TEST-*.xml'
+          check_name: OSS Integration Test Report
+
+      # Before Update PR Status, not after: the test step is continue-on-error, so job.status is
+      # still 'success' until this step's exit 1 flips it.
+      - name: Check Integration Tests Status
+        if: steps.integration_tests.outcome == 'failure'
+        run: |
+          echo "::error::Integration tests (OSS) failed. See the 'Run integration tests (OSS)' step above for the Gradle/test output, the 'Dump Conductor logs' step for server-side logs, and the 'Publish Test Report' step's JUnit summary for which test(s) failed."
+          exit 1
+
+      - name: Update PR Status
+        # Skipped on workflow_dispatch: there is no triggering run, so there is no PR head to
+        # report against and context.payload.workflow_run would be undefined.
+        if: ${{ always() && github.event_name == 'workflow_run' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha,
+              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
+              context: 'Integration Tests (OSS)',
+              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+              description: 'OSS integration tests ${{ job.status }}'
+            });
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,13 +12,29 @@ on:
         required: false
         type: string
 
+  # ---------------------------------------------------------------------------
+  # TEMPORARY -- REMOVE BEFORE MERGE.
+  #
+  # A workflow_run-triggered run always executes the copy of this file on the
+  # default branch, so the integration-tests-oss job below cannot be exercised
+  # from a pull request. push runs the branch's own copy, so this trigger is
+  # what lets the job actually run while it is being developed.
+  #
+  # Deleting this block is sufficient to revert; nothing else below depends on it.
+  # ---------------------------------------------------------------------------
+  push:
+    branches:
+      - e2e-against-conductor-with-local-script
+
 # allow this workflow to update the status of the PR that triggered it
 permissions:
   statuses: write
   checks: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  # head_branch is only set for workflow_run; fall back to the ref so runs from
+  # other triggers do not all collapse into one unnamed concurrency group.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -77,7 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Integration Tests (OSS)
     timeout-minutes: 30
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # The build-succeeded gate only makes sense for workflow_run, which is the only trigger that
+    # has a triggering run to inspect. Any other trigger is a direct request to run this suite.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     env:
       CONDUCTOR_SERVER_URL: http://localhost:8080/api
       CONDUCTOR_SERVER_TYPE: oss

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,47 @@ Run the SDK test suite:
 ./gradlew test jacocoTestReport
 ```
 
+### Running the OSS integration suite locally
+
+The `tests` module also has an integration suite (`-PIntegrationTests`) that runs against a
+real Conductor server, separate from the unit suite above. `scripts/run-integration-oss.sh`
+mirrors the `integration-tests-oss` job in `ci.yml`: it starts a local Conductor OSS +
+Postgres stack (defined in `scripts/docker-compose-oss.yaml`), waits for `/health`, runs the
+integration suite, and tears the stack down on exit.
+
+```shell
+scripts/run-integration-oss.sh                        # against `latest`
+scripts/run-integration-oss.sh --version 3.32.0-rc18
+scripts/run-integration-oss.sh --keep-up               # leave the stack running afterwards
+scripts/run-integration-oss.sh --include-gated         # also run tests normally skipped as Orkes-only
+```
+
+The script always prints the resolved `conductoross/conductor` tag and pulls it before
+starting the stack, since `latest` (the local default) is a mutable tag — without an
+explicit pull, `docker compose up` would silently reuse a stale cached image instead of
+fetching the current one. It also always runs Gradle with `--rerun-tasks`, since the `test`
+task's up-to-date check doesn't account for env vars like `CONDUCTOR_SERVER_TYPE` or the
+state of the live server underneath — without it, a rerun after changing gating or switching
+server versions could silently report a stale cached result instead of executing anything.
+
+The script doesn't pin a JDK itself, but CI runs on Zulu 21. If your local default JDK is
+newer (e.g. 23) you may hit `Unsupported class file major version` errors compiling tests —
+set `JAVA_HOME` explicitly to match CI:
+
+```shell
+JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-21.jdk/Contents/Home ./scripts/run-integration-oss.sh
+```
+
+Tests annotated `@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches =
+"oss")` skip themselves against plain OSS because they exercise Orkes-managed-only features
+(e.g. the Service Registry, Authorization, Prompts/Integrations, Environment Variables, and
+Secrets APIs, plus a handful of task/workflow endpoints OSS doesn't implement or that hit
+known Postgres-persistence bugs). Each annotation's `disabledReason` documents the specific,
+empirically-confirmed gap — treat those as the source of truth rather than a list here, since
+they can drift as OSS gains features. If you add or remove that annotation, re-verify against
+a freshly-pulled image first: a test that fails against a stale local image may pass against
+current OSS, and vice versa.
+
 Compile the maintained agent examples when changing their APIs or documentation:
 
 ```shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Run the SDK test suite:
 
 The `tests` module also has an integration suite (`-PIntegrationTests`) that runs against a
 real Conductor server, separate from the unit suite above. `scripts/run-integration-oss.sh`
-mirrors the `integration-tests-oss` job in `ci.yml`: it starts a local Conductor OSS +
+mirrors the `integration-tests-oss` job in `integration-tests.yml`: it starts a local Conductor OSS +
 Postgres stack (defined in `scripts/docker-compose-oss.yaml`), waits for `/health`, runs the
 integration suite, and tears the stack down on exit.
 

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
@@ -66,6 +66,7 @@ import com.netflix.conductor.sdk.workflow.executor.task.AnnotatedWorkerExecutor;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 
 public class WorkflowExecutor {
 
@@ -77,8 +78,15 @@ public class WorkflowExecutor {
     private final TypeReference<List<TaskDef>> listOfTaskDefs = new TypeReference<>() {
     };
 
+    private static final long DEFAULT_MONITOR_FAILURE_GIVE_UP_MILLIS = TimeUnit.MINUTES.toMillis(1);
+
     private final Map<String, CompletableFuture<Workflow>> runningWorkflowFutures =
             new ConcurrentHashMap<>();
+
+    /** When the current run of consecutive polling failures started, per workflow id. */
+    private final Map<String, Long> monitorFailingSince = new ConcurrentHashMap<>();
+
+    private volatile long monitorFailureGiveUpMillis = DEFAULT_MONITOR_FAILURE_GIVE_UP_MILLIS;
 
     private final ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper();
 
@@ -176,20 +184,55 @@ public class WorkflowExecutor {
                         CompletableFuture<Workflow> future = entry.getValue();
                         try {
                             Workflow workflow = workflowClient.getWorkflow(workflowId, true);
+                            monitorFailingSince.remove(workflowId);
                             if (workflow.getStatus().isTerminal()) {
                                 future.complete(workflow);
                                 runningWorkflowFutures.remove(workflowId);
                             }
                         } catch (Exception e) {
-                            // scheduleAtFixedRate silently kills all future ticks on any uncaught exception, so catch here instead of letting one transient error stop completion-tracking forever.
-                            LOGGER.warn("Error polling workflow {} for completion; will retry on "
-                                    + "the next tick", workflowId, e);
+                            // scheduleAtFixedRate silently kills all future ticks on any uncaught
+                            // exception, so one transient error here would otherwise stop completion
+                            // tracking for every workflow, forever. Catch, but do not retry forever:
+                            // a workflow id that never becomes resolvable would spin at the polling
+                            // interval indefinitely while its caller blocks with no signal.
+                            handleMonitorFailure(workflowId, future, e);
                         }
                     }
                 },
                 100,
                 100,
                 TimeUnit.MILLISECONDS);
+    }
+
+    private void handleMonitorFailure(String workflowId, CompletableFuture<Workflow> future, Exception e) {
+        long now = System.currentTimeMillis();
+        Long failingSince = monitorFailingSince.putIfAbsent(workflowId, now);
+
+        if (failingSince == null) {
+            LOGGER.warn("Error polling workflow {} for completion; will retry on the next tick",
+                    workflowId, e);
+            return;
+        }
+
+        long failingForMillis = now - failingSince;
+        if (failingForMillis < monitorFailureGiveUpMillis) {
+            // Already warned once for this run of failures. Staying at DEBUG keeps a persistently
+            // unresolvable workflow from emitting a stack trace on every tick.
+            LOGGER.debug("Still failing to poll workflow {} for completion ({} ms so far)",
+                    workflowId, failingForMillis, e);
+            return;
+        }
+
+        LOGGER.error("Giving up polling workflow {} for completion after {} ms of consecutive "
+                + "failures; completing its future exceptionally", workflowId, failingForMillis, e);
+        monitorFailingSince.remove(workflowId);
+        runningWorkflowFutures.remove(workflowId);
+        future.completeExceptionally(e);
+    }
+
+    @VisibleForTesting
+    void setMonitorFailureGiveUpMillis(long monitorFailureGiveUpMillis) {
+        this.monitorFailureGiveUpMillis = monitorFailureGiveUpMillis;
     }
 
     public void initWorkers(String... packagesToScan) {

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
@@ -66,7 +66,6 @@ import com.netflix.conductor.sdk.workflow.executor.task.AnnotatedWorkerExecutor;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
 
 public class WorkflowExecutor {
 
@@ -78,7 +77,8 @@ public class WorkflowExecutor {
     private final TypeReference<List<TaskDef>> listOfTaskDefs = new TypeReference<>() {
     };
 
-    private static final long DEFAULT_MONITOR_FAILURE_GIVE_UP_MILLIS = TimeUnit.MINUTES.toMillis(1);
+    /** Zero, i.e. never give up. See {@link #setMonitorFailureGiveUpMillis(long)}. */
+    private static final long DEFAULT_MONITOR_FAILURE_GIVE_UP_MILLIS = 0;
 
     private final Map<String, CompletableFuture<Workflow>> runningWorkflowFutures =
             new ConcurrentHashMap<>();
@@ -214,8 +214,9 @@ public class WorkflowExecutor {
             return;
         }
 
+        long giveUpMillis = monitorFailureGiveUpMillis;
         long failingForMillis = now - failingSince;
-        if (failingForMillis < monitorFailureGiveUpMillis) {
+        if (giveUpMillis <= 0 || failingForMillis < giveUpMillis) {
             // Already warned once for this run of failures. Staying at DEBUG keeps a persistently
             // unresolvable workflow from emitting a stack trace on every tick.
             LOGGER.debug("Still failing to poll workflow {} for completion ({} ms so far)",
@@ -230,9 +231,26 @@ public class WorkflowExecutor {
         future.completeExceptionally(e);
     }
 
-    @VisibleForTesting
-    void setMonitorFailureGiveUpMillis(long monitorFailureGiveUpMillis) {
+    /**
+     * How long the completion monitor keeps retrying a workflow whose status cannot be fetched
+     * before giving up on it.
+     *
+     * @param monitorFailureGiveUpMillis zero or negative (the default) to never give up: the
+     *     monitor retries such a workflow for as long as this executor lives, so a server outage
+     *     longer than any fixed budget — a rolling restart, a failover — does not strand futures
+     *     that would otherwise have completed once the server came back. A positive value bounds
+     *     that: once a workflow has failed to poll continuously for this long, the monitor stops
+     *     tracking it and completes its future exceptionally, so a caller blocked in
+     *     {@code executeWorkflow(...).get()} sees an {@link java.util.concurrent.ExecutionException}
+     *     rather than blocking indefinitely on a workflow id that will never resolve.
+     */
+    public void setMonitorFailureGiveUpMillis(long monitorFailureGiveUpMillis) {
         this.monitorFailureGiveUpMillis = monitorFailureGiveUpMillis;
+    }
+
+    /** @see #setMonitorFailureGiveUpMillis(long) */
+    public long getMonitorFailureGiveUpMillis() {
+        return monitorFailureGiveUpMillis;
     }
 
     public void initWorkers(String... packagesToScan) {

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
@@ -174,10 +174,16 @@ public class WorkflowExecutor {
                     for (Map.Entry<String, CompletableFuture<Workflow>> entry : runningWorkflowFutures.entrySet()) {
                         String workflowId = entry.getKey();
                         CompletableFuture<Workflow> future = entry.getValue();
-                        Workflow workflow = workflowClient.getWorkflow(workflowId, true);
-                        if (workflow.getStatus().isTerminal()) {
-                            future.complete(workflow);
-                            runningWorkflowFutures.remove(workflowId);
+                        try {
+                            Workflow workflow = workflowClient.getWorkflow(workflowId, true);
+                            if (workflow.getStatus().isTerminal()) {
+                                future.complete(workflow);
+                                runningWorkflowFutures.remove(workflowId);
+                            }
+                        } catch (Exception e) {
+                            // scheduleAtFixedRate silently kills all future ticks on any uncaught exception, so catch here instead of letting one transient error stop completion-tracking forever.
+                            LOGGER.warn("Error polling workflow {} for completion; will retry on "
+                                    + "the next tick", workflowId, e);
                         }
                     }
                 },

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
@@ -76,8 +76,9 @@ public class AnnotatedWorkerExecutor {
      *     implementation
      */
     public synchronized void initWorkers(String... basePackages) {
+        // scanWorkers() -> initWorkersFromClasses() -> initWorkersFromInstances() already calls startPolling();
+        // an extra call here used to race with that one and could drop a task polled by the runner it replaces.
         scanWorkers(basePackages);
-        startPolling();
     }
 
     public synchronized void initWorkersFromInstances(List<Object> workerInstances) {
@@ -157,7 +158,10 @@ public class AnnotatedWorkerExecutor {
             initWorkersFromClasses(classes);
 
         } catch (Exception e) {
-            LOGGER.error("Error while scanning for workers: ", e);
+            // Rethrow (unchecked) rather than swallow: initWorkers() no longer has its own startPolling()
+            // fallback, so a swallowed failure here would otherwise leave the caller believing workers are
+            // running when none were ever started.
+            throw new RuntimeException("Error while scanning for workers", e);
         }
     }
 

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
@@ -118,10 +118,18 @@ public class AnnotatedWorkerExecutor {
     }
 
 
-    /** Shuts down the workers */
-    public void shutdown() {
+    /**
+     * Shuts down the workers.
+     *
+     * <p>Clears the task runner as well as shutting it down, so a later {@link #startPolling()}
+     * builds a fresh one and resumes. A {@link TaskRunnerConfigurer} is single-use — its
+     * shutdown closes the executor backing it — so leaving the field set would make
+     * startPolling() take its already-polling fast path and never poll again.
+     */
+    public synchronized void shutdown() {
         if (taskRunner != null) {
             taskRunner.shutdown();
+            taskRunner = null;
         }
     }
 
@@ -177,7 +185,15 @@ public class AnnotatedWorkerExecutor {
         return false;
     }
 
-    public void addBean(Object bean) {
+    /**
+     * Registers every {@link WorkerTask}-annotated method on the bean as a worker.
+     *
+     * <p>Synchronized because it is the public entry point that mutates the worker set and the
+     * {@code workersChanged} flag {@link #startPolling()} reads to decide whether a restart is
+     * needed. Without a common lock, a worker added on another thread could be missed and never
+     * polled.
+     */
+    public synchronized void addBean(Object bean) {
         Class<?> clazz = bean.getClass();
         for (Method method : clazz.getMethods()) {
             WorkerTask annotation = method.getAnnotation(WorkerTask.class);

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
@@ -52,6 +52,12 @@ public class AnnotatedWorkerExecutor {
 
     private final Set<String> scannedPackages = new HashSet<>();
 
+    /**
+     * Set whenever a worker is added, cleared whenever {@link #startPolling()} builds a task runner.
+     * Lets startPolling() distinguish a real (re)start from a redundant duplicate call.
+     */
+    private boolean workersChanged = false;
+
     private final WorkerConfiguration workerConfiguration;
 
     public AnnotatedWorkerExecutor(TaskClient taskClient) {
@@ -76,9 +82,11 @@ public class AnnotatedWorkerExecutor {
      *     implementation
      */
     public synchronized void initWorkers(String... basePackages) {
-        // scanWorkers() -> initWorkersFromClasses() -> initWorkersFromInstances() already calls startPolling();
-        // an extra call here used to race with that one and could drop a task polled by the runner it replaces.
         scanWorkers(basePackages);
+        // scanWorkers() -> initWorkersFromClasses() -> initWorkersFromInstances() already reaches
+        // startPolling(). This second call is therefore redundant, but startPolling() is idempotent
+        // while the worker set is unchanged, so it is a no-op rather than a task runner restart.
+        startPolling();
     }
 
     public synchronized void initWorkersFromInstances(List<Object> workerInstances) {
@@ -158,10 +166,7 @@ public class AnnotatedWorkerExecutor {
             initWorkersFromClasses(classes);
 
         } catch (Exception e) {
-            // Rethrow (unchecked) rather than swallow: initWorkers() no longer has its own startPolling()
-            // fallback, so a swallowed failure here would otherwise leave the caller believing workers are
-            // running when none were ever started.
-            throw new RuntimeException("Error while scanning for workers", e);
+            LOGGER.error("Error while scanning for workers: ", e);
         }
     }
 
@@ -226,6 +231,7 @@ public class AnnotatedWorkerExecutor {
         for (int i = 0; i < pollerCount; i++) {
             workers.add(executor);
         }
+        workersChanged = true;
 
         LOGGER.info(
                 "Adding worker for task {}, method {} with threadCount {} and polling interval set to {} ms",
@@ -235,8 +241,25 @@ public class AnnotatedWorkerExecutor {
                 pollingInterval);
     }
 
-    public void startPolling() {
+    /**
+     * Builds a {@link TaskRunnerConfigurer} over the currently registered workers and starts polling.
+     *
+     * <p>Idempotent: if a task runner is already polling and no worker has been added since it was
+     * built, this returns without doing anything. Restarting unnecessarily would stand up a second
+     * runner polling the same task types and only shut the first one down afterwards, so a task
+     * already leased by the outgoing runner could be left in-progress until its response timeout
+     * expired. Callers that add workers and call this again still get the intended restart.
+     */
+    public synchronized void startPolling() {
         if (workers.isEmpty()) {
+            return;
+        }
+
+        if (taskRunner != null && !workersChanged) {
+            LOGGER.debug(
+                    "Task runner is already polling {} workers and the worker set is unchanged; "
+                            + "skipping redundant restart.",
+                    workers.size());
             return;
         }
 
@@ -256,6 +279,8 @@ public class AnnotatedWorkerExecutor {
 
         taskRunner = builder.build();
         taskRunner.init();
+
+        workersChanged = false;
 
         oldTaskRunner.ifPresent(taskRunner -> {
             LOGGER.trace("Shutting down previous task runner with {} workers.", taskRunner.getWorkerCount());

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/SchedulerResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/SchedulerResource.java
@@ -167,14 +167,19 @@ public class SchedulerResource {
     /**
      * Enterprise scheduler endpoints accept GET while OSS accepts PUT. Retry only
      * a method-not-allowed response so application and authentication failures
-     * retain their original behavior.
+     * retain their original behavior. Orkes Enterprise reports this as a proper
+     * 405; plain OSS Conductor instead reports it as a 500 with a "Request
+     * method '...' is not supported" message (confirmed empirically) -- treat
+     * both as a signal to retry with PUT.
      */
     private void executeGetThenPutOnMethodNotAllowed(
             ConductorClientRequest getRequest, ConductorClientRequest putRequest) {
         try {
             client.execute(getRequest);
         } catch (ConductorClientException e) {
-            if (e.getStatus() != 405) {
+            if (e.getStatus() != 405
+                    && !(e.getStatus() == 500 && e.getMessage() != null
+                            && e.getMessage().contains("is not supported"))) {
                 throw e;
             }
             client.execute(putRequest);

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/SchedulerResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/SchedulerResource.java
@@ -167,19 +167,14 @@ public class SchedulerResource {
     /**
      * Enterprise scheduler endpoints accept GET while OSS accepts PUT. Retry only
      * a method-not-allowed response so application and authentication failures
-     * retain their original behavior. Orkes Enterprise reports this as a proper
-     * 405; plain OSS Conductor instead reports it as a 500 with a "Request
-     * method '...' is not supported" message (confirmed empirically) -- treat
-     * both as a signal to retry with PUT.
+     * retain their original behavior.
      */
     private void executeGetThenPutOnMethodNotAllowed(
             ConductorClientRequest getRequest, ConductorClientRequest putRequest) {
         try {
             client.execute(getRequest);
         } catch (ConductorClientException e) {
-            if (e.getStatus() != 405
-                    && !(e.getStatus() == 500 && e.getMessage() != null
-                            && e.getMessage().contains("is not supported"))) {
+            if (e.getStatus() != 405) {
                 throw e;
             }
             client.execute(putRequest);

--- a/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutorMonitorTests.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutorMonitorTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sdk.workflow.executor;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.client.http.MetadataClient;
+import com.netflix.conductor.client.http.TaskClient;
+import com.netflix.conductor.client.http.WorkflowClient;
+import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
+import com.netflix.conductor.common.run.Workflow;
+import com.netflix.conductor.sdk.workflow.executor.task.AnnotatedWorkerExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the completion-tracking monitor started by {@link WorkflowExecutor}'s constructors. The
+ * monitor runs under {@code scheduleAtFixedRate}, which cancels all future ticks on any uncaught
+ * exception, so a single failed {@code getWorkflow} call must not be allowed to escape.
+ */
+public class WorkflowExecutorMonitorTests {
+
+    private static final String WORKFLOW_ID = "test-workflow-id";
+
+    private WorkflowExecutor executorFor(WorkflowClient workflowClient) {
+        return new WorkflowExecutor(
+                mock(TaskClient.class),
+                workflowClient,
+                mock(MetadataClient.class),
+                mock(AnnotatedWorkerExecutor.class));
+    }
+
+    @Test
+    @DisplayName("the monitor should keep polling after a transient getWorkflow failure")
+    void monitorSurvivesTransientPollFailure() throws Exception {
+        Workflow completed = new Workflow();
+        completed.setStatus(Workflow.WorkflowStatus.COMPLETED);
+
+        WorkflowClient workflowClient = mock(WorkflowClient.class);
+        when(workflowClient.startWorkflow(any(StartWorkflowRequest.class))).thenReturn(WORKFLOW_ID);
+        when(workflowClient.getWorkflow(anyString(), anyBoolean()))
+                .thenThrow(new RuntimeException("transient failure"))
+                .thenReturn(completed);
+
+        WorkflowExecutor executor = executorFor(workflowClient);
+        try {
+            CompletableFuture<Workflow> future = executor.executeWorkflow("wf", 1, Map.of());
+
+            Workflow result = future.get(5, TimeUnit.SECONDS);
+
+            assertEquals(Workflow.WorkflowStatus.COMPLETED, result.getStatus());
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("the monitor should give up and fail the future once the failure budget is spent")
+    void monitorGivesUpOnPersistentPollFailure() {
+        WorkflowClient workflowClient = mock(WorkflowClient.class);
+        when(workflowClient.startWorkflow(any(StartWorkflowRequest.class))).thenReturn(WORKFLOW_ID);
+        when(workflowClient.getWorkflow(anyString(), anyBoolean()))
+                .thenThrow(new RuntimeException("permanent failure"));
+
+        WorkflowExecutor executor = executorFor(workflowClient);
+        try {
+            // Zero budget: give up on the tick after the first failure, so the test does not have
+            // to sit out the production budget.
+            executor.setMonitorFailureGiveUpMillis(0);
+
+            CompletableFuture<Workflow> future = executor.executeWorkflow("wf", 1, Map.of());
+
+            ExecutionException thrown = assertThrows(
+                    ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+
+            assertInstanceOf(RuntimeException.class, thrown.getCause());
+            assertEquals("permanent failure", thrown.getCause().getMessage());
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutorMonitorTests.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutorMonitorTests.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +46,8 @@ import static org.mockito.Mockito.when;
 public class WorkflowExecutorMonitorTests {
 
     private static final String WORKFLOW_ID = "test-workflow-id";
+
+    private static final String OTHER_WORKFLOW_ID = "other-test-workflow-id";
 
     private WorkflowExecutor executorFor(WorkflowClient workflowClient) {
         return new WorkflowExecutor(
@@ -87,9 +91,10 @@ public class WorkflowExecutorMonitorTests {
 
         WorkflowExecutor executor = executorFor(workflowClient);
         try {
-            // Zero budget: give up on the tick after the first failure, so the test does not have
-            // to sit out the production budget.
-            executor.setMonitorFailureGiveUpMillis(0);
+            // 1ms budget: the monitor ticks every 100ms, so the second consecutive failure is
+            // already past it. Keeps the test off the wall clock while still exercising a real
+            // (positive, opt-in) budget rather than the never-give-up default.
+            executor.setMonitorFailureGiveUpMillis(1);
 
             CompletableFuture<Workflow> future = executor.executeWorkflow("wf", 1, Map.of());
 
@@ -98,6 +103,40 @@ public class WorkflowExecutorMonitorTests {
 
             assertInstanceOf(RuntimeException.class, thrown.getCause());
             assertEquals("permanent failure", thrown.getCause().getMessage());
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("by default the monitor should never give up, and one bad workflow should not stall the rest")
+    void monitorDoesNotGiveUpByDefault() throws Exception {
+        Workflow completed = new Workflow();
+        completed.setStatus(Workflow.WorkflowStatus.COMPLETED);
+
+        WorkflowClient workflowClient = mock(WorkflowClient.class);
+        when(workflowClient.startWorkflow(any(StartWorkflowRequest.class)))
+                .thenReturn(WORKFLOW_ID)
+                .thenReturn(OTHER_WORKFLOW_ID);
+        when(workflowClient.getWorkflow(eq(WORKFLOW_ID), anyBoolean()))
+                .thenThrow(new RuntimeException("permanent failure"));
+        when(workflowClient.getWorkflow(eq(OTHER_WORKFLOW_ID), anyBoolean()))
+                .thenReturn(completed);
+
+        WorkflowExecutor executor = executorFor(workflowClient);
+        try {
+            assertEquals(0, executor.getMonitorFailureGiveUpMillis(), "give-up should be off by default");
+
+            CompletableFuture<Workflow> failing = executor.executeWorkflow("wf", 1, Map.of());
+            CompletableFuture<Workflow> healthy = executor.executeWorkflow("wf", 1, Map.of());
+
+            // The unresolvable workflow must not take the monitor down with it: a sibling
+            // registered on the same tick loop still completes.
+            assertEquals(Workflow.WorkflowStatus.COMPLETED, healthy.get(5, TimeUnit.SECONDS).getStatus());
+
+            // ...and the unresolvable one stays pending rather than being failed, which is the
+            // pre-bounded-retry behavior callers depend on across a server restart.
+            assertThrows(TimeoutException.class, () -> failing.get(1, TimeUnit.SECONDS));
         } finally {
             executor.shutdown();
         }

--- a/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
@@ -85,6 +85,60 @@ public class AnnotatedWorkerTests {
     }
 
     @Test
+    @DisplayName("initWorkers should leave exactly one task runner polling")
+    void initWorkersStartsASingleTaskRunner() {
+        var executor = new AnnotatedWorkerExecutor(mock(TaskClient.class));
+        executor.initWorkers("com.netflix.conductor.sdk.workflow.executor.task.workers1");
+
+        var runner = executor.getTaskRunner();
+        assertNotNull(runner);
+
+        // The shape used by examples/old/.../taskdomains/Main.java and by callers following the
+        // docs: initWorkers() followed by an explicit startPolling(). This must not stand up a
+        // replacement runner alongside the live one.
+        executor.startPolling();
+        assertSame(runner, executor.getTaskRunner());
+
+        executor.shutdown();
+    }
+
+    @Test
+    @DisplayName("startPolling should be a no-op while the worker set is unchanged")
+    void startPollingIsIdempotent() {
+        var executor = new AnnotatedWorkerExecutor(mock(TaskClient.class));
+        executor.addBean(new MultipleInputParams());
+
+        executor.startPolling();
+        var first = executor.getTaskRunner();
+        assertNotNull(first);
+
+        executor.startPolling();
+        executor.startPolling();
+        assertSame(first, executor.getTaskRunner());
+
+        executor.shutdown();
+    }
+
+    @Test
+    @DisplayName("startPolling should still rebuild the task runner once new workers are added")
+    void startPollingRebuildsWhenWorkersAreAdded() {
+        var executor = new AnnotatedWorkerExecutor(mock(TaskClient.class));
+        executor.addBean(new MultipleInputParams());
+        executor.startPolling();
+        var first = executor.getTaskRunner();
+        assertEquals(1, first.getWorkerCount());
+
+        executor.addBean(new AnotherAnnotationInput());
+        executor.startPolling();
+        var second = executor.getTaskRunner();
+
+        assertNotSame(first, second);
+        assertEquals(2, second.getWorkerCount());
+
+        executor.shutdown();
+    }
+
+    @Test
     @DisplayName("it should handle null values when InputParam is a List")
     void nullListAsInputParam() throws NoSuchMethodException {
         var worker = new CarWorker1();

--- a/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
@@ -139,6 +139,30 @@ public class AnnotatedWorkerTests {
     }
 
     @Test
+    @DisplayName("startPolling should build a fresh task runner after a shutdown")
+    void startPollingRestartsAfterShutdown() {
+        var executor = new AnnotatedWorkerExecutor(mock(TaskClient.class));
+        executor.addBean(new MultipleInputParams());
+        executor.startPolling();
+        var first = executor.getTaskRunner();
+        assertNotNull(first);
+
+        // A TaskRunnerConfigurer is single-use, so shutdown() has to clear the field as well as
+        // shut the runner down. Otherwise startPolling()'s idempotence check sees a non-null
+        // runner with an unchanged worker set and silently declines to poll ever again.
+        executor.shutdown();
+        assertNull(executor.getTaskRunner());
+
+        executor.startPolling();
+        var second = executor.getTaskRunner();
+        assertNotNull(second);
+        assertNotSame(first, second);
+        assertEquals(1, second.getWorkerCount());
+
+        executor.shutdown();
+    }
+
+    @Test
     @DisplayName("it should handle null values when InputParam is a List")
     void nullListAsInputParam() throws NoSuchMethodException {
         var worker = new CarWorker1();

--- a/scripts/docker-compose-oss.yaml
+++ b/scripts/docker-compose-oss.yaml
@@ -1,0 +1,28 @@
+services:
+  conductor-server:
+    image: conductoross/conductor:${OSS_CONDUCTOR_VERSION:-latest}
+    environment:
+      - CONFIG_PROP=config-postgres.properties
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-I", "-XGET", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+    links:
+      - conductor-postgres:postgresdb
+    depends_on:
+      conductor-postgres:
+        condition: service_healthy
+
+  conductor-postgres:
+    image: postgres:16
+    environment:
+      - POSTGRES_USER=conductor
+      - POSTGRES_PASSWORD=conductor
+    healthcheck:
+      test: timeout 5 bash -c 'cat < /dev/null > /dev/tcp/localhost/5432'
+      interval: 5s
+      timeout: 5s
+      retries: 12

--- a/scripts/docker-compose-oss.yaml
+++ b/scripts/docker-compose-oss.yaml
@@ -1,13 +1,9 @@
 # Conductor OSS stack used to run the SDK integration tests against open-source Conductor.
 # Shared by scripts/run-integration-oss.sh and the integration-tests-oss job in
-# .github/workflows/ci.yml.
+# .github/workflows/integration-tests.yml.
 #
 # OSS_CONDUCTOR_VERSION defaults to `latest` for local runs; CI pins it via the
 # E2E_TEST_OSS_CONDUCTOR_VERSION org variable (or a workflow_dispatch input).
-#
-# Per-repo name; unnamed, the project defaults to this file's dir (`scripts`) in every SDK repo
-# and stacks collide -- both on the project name and on port 8080.
-name: java-sdk-oss-e2e
 
 services:
   conductor-server:

--- a/scripts/docker-compose-oss.yaml
+++ b/scripts/docker-compose-oss.yaml
@@ -1,3 +1,14 @@
+# Conductor OSS stack used to run the SDK integration tests against open-source Conductor.
+# Shared by scripts/run-integration-oss.sh and the integration-tests-oss job in
+# .github/workflows/ci.yml.
+#
+# OSS_CONDUCTOR_VERSION defaults to `latest` for local runs; CI pins it via the
+# E2E_TEST_OSS_CONDUCTOR_VERSION org variable (or a workflow_dispatch input).
+#
+# Per-repo name; unnamed, the project defaults to this file's dir (`scripts`) in every SDK repo
+# and stacks collide -- both on the project name and on port 8080.
+name: java-sdk-oss-e2e
+
 services:
   conductor-server:
     image: conductoross/conductor:${OSS_CONDUCTOR_VERSION:-latest}

--- a/scripts/run-integration-oss.sh
+++ b/scripts/run-integration-oss.sh
@@ -2,7 +2,7 @@
 #
 # Spin up a local Conductor OSS stack and run the `tests` module's
 # integration suite against it, mirroring the `integration-tests-oss` job in
-# .github/workflows/integration-tests-oss.yml. Orkes-Enterprise-only test
+# .github/workflows/ci.yml. Orkes-Enterprise-only test
 # classes are annotated with
 # @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss")
 # so they skip themselves when it's set (see the individual test files for
@@ -87,6 +87,13 @@ done
 echo "Conductor is up."
 
 export CONDUCTOR_SERVER_URL="http://localhost:8080/api"
+
+# Plain OSS Conductor has no authentication layer and no /token endpoint. ClientTestUtil builds
+# its client with useEnvVariables(true), and ApiClient.applyEnvVariables() attaches credentials
+# whenever both of these are present -- so a shell that still has them exported for the Orkes
+# suite would send the whole run through an auth flow the local server cannot serve.
+unset CONDUCTOR_AUTH_KEY CONDUCTOR_AUTH_SECRET
+unset CONDUCTOR_SERVER_AUTH_KEY CONDUCTOR_SERVER_AUTH_SECRET
 
 if [[ "${INCLUDE_GATED}" == "1" ]]; then
   echo "--include-gated set: leaving CONDUCTOR_SERVER_TYPE unset, so tests normally" \

--- a/scripts/run-integration-oss.sh
+++ b/scripts/run-integration-oss.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Spin up a local Conductor OSS stack and run the `tests` module's
+# integration suite against it, mirroring the `integration-tests-oss` job in
+# .github/workflows/integration-tests-oss.yml. Orkes-Enterprise-only test
+# classes are annotated with
+# @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss")
+# so they skip themselves when it's set (see the individual test files for
+# the empirically-confirmed gaps).
+#
+# The stack (Conductor OSS + Postgres) is defined in
+# scripts/docker-compose-oss.yaml and is torn down automatically on exit. The
+# image is always pulled before starting, since `latest` (the local default)
+# is a mutable tag and a cached copy would otherwise go stale silently.
+#
+# Usage:
+#   scripts/run-integration-oss.sh [--keep-up] [--version <tag>] [--include-gated] [-- gradle args]
+# Examples:
+#   scripts/run-integration-oss.sh
+#   scripts/run-integration-oss.sh --version 3.32.0-rc18
+#   scripts/run-integration-oss.sh --keep-up
+#   scripts/run-integration-oss.sh --include-gated       # also run tests normally skipped as Orkes-only
+#   scripts/run-integration-oss.sh -- --tests "*WorkflowClientTests"
+set -euo pipefail
+
+KEEP_UP=0
+INCLUDE_GATED=0
+extra=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-up) KEEP_UP=1; shift ;;
+    --version) OSS_CONDUCTOR_VERSION="${2:?--version needs a tag}"; shift 2 ;;
+    --include-gated) INCLUDE_GATED=1; shift ;;
+    -h|--help)
+      echo "Usage: $0 [--keep-up] [--version <tag>] [--include-gated] [-- gradle args]"
+      exit 0
+      ;;
+    --) shift; extra=("$@"); break ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+export OSS_CONDUCTOR_VERSION="${OSS_CONDUCTOR_VERSION:-latest}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose-oss.yaml"
+cd "${REPO_ROOT}"
+
+compose() { docker compose -f "${COMPOSE_FILE}" "$@"; }
+
+cleanup() {
+  if [[ "${KEEP_UP}" == "1" ]]; then
+    echo "--keep-up set: leaving the OSS stack running. Tear down with:"
+    echo "  docker compose -f ${COMPOSE_FILE} down -v"
+    return
+  fi
+  echo "Tearing down Conductor OSS stack..."
+  compose down -v || true
+}
+trap cleanup EXIT
+
+echo "Using conductoross/conductor:${OSS_CONDUCTOR_VERSION}"
+
+# `docker compose up` only pulls an image when it is missing locally, so a
+# previously-cached `latest` (or any other mutable tag) would silently be
+# reused instead of getting the current version. Pull unconditionally so the
+# stack always reflects the tag we just printed.
+echo "Pulling conductoross/conductor:${OSS_CONDUCTOR_VERSION} to ensure it's current..."
+compose pull conductor-server
+
+echo "Starting Conductor OSS stack..."
+compose up -d
+
+echo "Waiting for Conductor to be healthy..."
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
+deadline=$(( SECONDS + HEALTH_TIMEOUT ))
+until curl -sf http://localhost:8080/health >/dev/null 2>&1; do
+  if (( SECONDS >= deadline )); then
+    echo "Error: Conductor did not become healthy within ${HEALTH_TIMEOUT}s." >&2
+    compose logs conductor-server || true
+    exit 1
+  fi
+  sleep 5
+done
+echo "Conductor is up."
+
+export CONDUCTOR_SERVER_URL="http://localhost:8080/api"
+
+if [[ "${INCLUDE_GATED}" == "1" ]]; then
+  echo "--include-gated set: leaving CONDUCTOR_SERVER_TYPE unset, so tests normally" \
+       "skipped as Orkes-only will run against OSS too."
+  unset CONDUCTOR_SERVER_TYPE || true
+else
+  export CONDUCTOR_SERVER_TYPE="oss"
+fi
+
+
+# --rerun-tasks: the `test` task's up-to-date check only considers the compiled
+# test classpath, not env vars like CONDUCTOR_SERVER_URL/CONDUCTOR_SERVER_TYPE
+# or the state of the live server underneath. Without this, Gradle can report
+# BUILD SUCCESSFUL while silently reusing a stale cached result from a
+# previous run against a different server/tag/gating state instead of
+# actually executing anything.
+./gradlew :tests:test -PIntegrationTests --rerun-tasks ${extra[@]+"${extra[@]}"}

--- a/scripts/run-integration-oss.sh
+++ b/scripts/run-integration-oss.sh
@@ -2,7 +2,7 @@
 #
 # Spin up a local Conductor OSS stack and run the `tests` module's
 # integration suite against it, mirroring the `integration-tests-oss` job in
-# .github/workflows/ci.yml. Orkes-Enterprise-only test
+# .github/workflows/integration-tests.yml. Orkes-Enterprise-only test
 # classes are annotated with
 # @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss")
 # so they skip themselves when it's set (see the individual test files for

--- a/tests/src/test/java/io/orkes/conductor/client/ServiceRegistryClientTest.java
+++ b/tests/src/test/java/io/orkes/conductor/client/ServiceRegistryClientTest.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.common.model.OrkesCircuitBreakerConfig;
 import com.netflix.conductor.common.model.ServiceMethod;
@@ -30,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+        disabledReason = "the Service Registry API (/registry/service) is not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/registry/service')")
 public class ServiceRegistryClientTest {
 
     private static final String PROTO_FILENAME = "compiled.bin";

--- a/tests/src/test/java/io/orkes/conductor/client/WorkflowRetryTest.java
+++ b/tests/src/test/java/io/orkes/conductor/client/WorkflowRetryTest.java
@@ -18,6 +18,7 @@ import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
@@ -36,6 +37,8 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+        disabledReason = "workflowClient.uploadCompletedWorkflows() (/workflow/document-store/upload) is not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/workflow/document-store/upload')")
 public class WorkflowRetryTest {
     private final OrkesMetadataClient metadataClient;
     private final OrkesWorkflowClient workflowClient;

--- a/tests/src/test/java/io/orkes/conductor/client/http/AuthorizationClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/AuthorizationClientTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
@@ -49,6 +50,8 @@ import io.orkes.conductor.client.model.UpsertUserRequest;
 import io.orkes.conductor.client.util.ClientTestUtil;
 import io.orkes.conductor.client.util.Commons;
 
+@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+        disabledReason = "the Authorization APIs (applications/users/groups/roles/permissions) are not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/applications|users|groups|...')")
 public class AuthorizationClientTests {
     private static AuthorizationClient authorizationClient;
     private static String applicationId;

--- a/tests/src/test/java/io/orkes/conductor/client/http/EnvironmentClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/EnvironmentClientTests.java
@@ -19,11 +19,14 @@ import io.orkes.conductor.client.util.ClientTestUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+        disabledReason = "environment variable writes are not supported by plain OSS Conductor, confirmed empirically: OSS added read-only GET /environment in 3.32.0-rc.9 but PUT /environment/{key} still 405s ('Request method 'PUT' is not supported')")
 public class EnvironmentClientTests {
 
     private static EnvironmentClient envClient;

--- a/tests/src/test/java/io/orkes/conductor/client/http/EventClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/EventClientTests.java
@@ -35,7 +35,11 @@ public class EventClientTests {
         try {
             eventClient.unregisterEventHandler(EVENT_NAME);
         } catch (ConductorClientException e) {
-            if (e.getStatus() != 404) {
+            // Best-effort cleanup: tolerate "doesn't exist" regardless of how the
+            // server reports it. Orkes Enterprise returns 404; plain OSS Conductor
+            // returns a 500 with a "not found" message instead (confirmed
+            // empirically) -- treat both as success for this purpose.
+            if (e.getStatus() != 404 && !e.getMessage().contains("not found")) {
                 throw e;
             }
         }

--- a/tests/src/test/java/io/orkes/conductor/client/http/EventClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/EventClientTests.java
@@ -24,6 +24,7 @@ import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
 
 import io.orkes.conductor.client.util.ClientTestUtil;
 import io.orkes.conductor.client.util.Commons;
+import io.orkes.conductor.client.util.TestUtil;
 
 public class EventClientTests {
     private static final String EVENT_NAME = "test_sdk_java_event_name";
@@ -35,13 +36,9 @@ public class EventClientTests {
         try {
             eventClient.unregisterEventHandler(EVENT_NAME);
         } catch (ConductorClientException e) {
-            // Best-effort cleanup: tolerate "doesn't exist" regardless of how the
-            // server reports it. Orkes Enterprise returns 404; plain OSS Conductor
-            // returns a 500 with a "not found" message instead (confirmed
-            // empirically) -- treat both as success for this purpose.
-            if (e.getStatus() != 404 && !e.getMessage().contains("not found")) {
-                throw e;
-            }
+            // Best-effort cleanup: tolerate "doesn't exist" in whichever shape the server
+            // we're running against actually reports it.
+            TestUtil.assertNotFoundOrRethrow(e, "not found");
         }
         EventHandler eventHandler = getEventHandler();
         eventClient.registerEventHandler(eventHandler);

--- a/tests/src/test/java/io/orkes/conductor/client/http/MetadataClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/MetadataClientTests.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
@@ -38,7 +39,11 @@ public class MetadataClientTests {
         try {
             metadataClient.unregisterTaskDef(Commons.TASK_NAME);
         } catch (ConductorClientException e) {
-            if (e.getStatus() != 404) {
+            // Best-effort cleanup: tolerate "doesn't exist" regardless of how the
+            // server reports it. Orkes Enterprise returns 404; plain OSS Conductor
+            // returns a 500 with a "No such task definition" message instead
+            // (confirmed empirically) -- treat both as success for this purpose.
+            if (e.getStatus() != 404 && !e.getMessage().contains("No such task definition")) {
                 throw e;
             }
         }
@@ -54,16 +59,41 @@ public class MetadataClientTests {
         try {
             metadataClient.unregisterWorkflowDef(Commons.WORKFLOW_NAME, Commons.WORKFLOW_VERSION);
         } catch (ConductorClientException e) {
-            if (e.getStatus() != 404) {
+            // Best-effort cleanup: tolerate "doesn't exist" regardless of how the
+            // server reports it. Orkes Enterprise returns 404; plain OSS Conductor
+            // returns a 500 with a "No such workflow definition" message instead
+            // (confirmed empirically) -- treat both as success for this purpose.
+            if (e.getStatus() != 404 && !e.getMessage().contains("No such workflow definition")) {
                 throw e;
             }
         }
         metadataClient.registerTaskDefs(List.of(Commons.getTaskDef()));
         WorkflowDef workflowDef = WorkflowUtil.getWorkflowDef();
-        metadataClient.registerWorkflowDef(workflowDef);
+        try {
+            metadataClient.registerWorkflowDef(workflowDef);
+        } catch (ConductorClientException e) {
+            // Commons.WORKFLOW_NAME/VERSION is shared fixture data used by several
+            // test classes in this suite; tolerate an "already exists" collision
+            // here since the update/overwrite calls below re-establish the
+            // intended definition regardless of which class registered it first.
+            if (e.getStatus() != 500 || !e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
         metadataClient.updateWorkflowDefs(List.of(workflowDef));
         metadataClient.updateWorkflowDefs(List.of(workflowDef), true);
-        metadataClient.registerWorkflowDef(workflowDef, true);
+        try {
+            metadataClient.registerWorkflowDef(workflowDef, true);
+        } catch (ConductorClientException e) {
+            // The overwrite=true query param on POST /metadata/workflow is not
+            // honored by plain OSS Conductor, confirmed empirically (it still
+            // rejects an existing name+version instead of overwriting); the
+            // updateWorkflowDefs(..., true) call above already re-established
+            // the intended definition.
+            if (e.getStatus() != 500 || !e.getMessage().contains("already exists")) {
+                throw e;
+            }
+        }
         ((OrkesMetadataClient) metadataClient)
                 .getWorkflowDefWithMetadata(Commons.WORKFLOW_NAME, Commons.WORKFLOW_VERSION);
         WorkflowDef receivedWorkflowDef = metadataClient.getWorkflowDef(Commons.WORKFLOW_NAME,
@@ -73,6 +103,8 @@ public class MetadataClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "task tagging (/metadata/task/{name}/tags) is not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/metadata/task/{name}/tags')")
     void tagTask() throws Exception {
         metadataClient.registerTaskDefs(List.of(Commons.getTaskDef()));
         try {
@@ -98,6 +130,8 @@ public class MetadataClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "workflow tagging (/metadata/workflow/{name}/tags) is not implemented by plain OSS Conductor, confirmed empirically (the {version} path segment ends up matching the literal string \"tags\" instead, a server-side routing collision)")
     void tagWorkflow() {
         TagObject tagObject = Commons.getTagObject();
         try {

--- a/tests/src/test/java/io/orkes/conductor/client/http/MetadataClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/MetadataClientTests.java
@@ -39,13 +39,9 @@ public class MetadataClientTests {
         try {
             metadataClient.unregisterTaskDef(Commons.TASK_NAME);
         } catch (ConductorClientException e) {
-            // Best-effort cleanup: tolerate "doesn't exist" regardless of how the
-            // server reports it. Orkes Enterprise returns 404; plain OSS Conductor
-            // returns a 500 with a "No such task definition" message instead
-            // (confirmed empirically) -- treat both as success for this purpose.
-            if (e.getStatus() != 404 && !e.getMessage().contains("No such task definition")) {
-                throw e;
-            }
+            // Best-effort cleanup: tolerate "doesn't exist" in whichever shape the server
+            // we're running against actually reports it.
+            TestUtil.assertNotFoundOrRethrow(e, "No such task definition");
         }
         TaskDef taskDef = Commons.getTaskDef();
         metadataClient.registerTaskDefs(List.of(taskDef));
@@ -59,13 +55,9 @@ public class MetadataClientTests {
         try {
             metadataClient.unregisterWorkflowDef(Commons.WORKFLOW_NAME, Commons.WORKFLOW_VERSION);
         } catch (ConductorClientException e) {
-            // Best-effort cleanup: tolerate "doesn't exist" regardless of how the
-            // server reports it. Orkes Enterprise returns 404; plain OSS Conductor
-            // returns a 500 with a "No such workflow definition" message instead
-            // (confirmed empirically) -- treat both as success for this purpose.
-            if (e.getStatus() != 404 && !e.getMessage().contains("No such workflow definition")) {
-                throw e;
-            }
+            // Best-effort cleanup: tolerate "doesn't exist" in whichever shape the server
+            // we're running against actually reports it.
+            TestUtil.assertNotFoundOrRethrow(e, "No such workflow definition");
         }
         metadataClient.registerTaskDefs(List.of(Commons.getTaskDef()));
         WorkflowDef workflowDef = WorkflowUtil.getWorkflowDef();
@@ -82,18 +74,10 @@ public class MetadataClientTests {
         }
         metadataClient.updateWorkflowDefs(List.of(workflowDef));
         metadataClient.updateWorkflowDefs(List.of(workflowDef), true);
-        try {
-            metadataClient.registerWorkflowDef(workflowDef, true);
-        } catch (ConductorClientException e) {
-            // The overwrite=true query param on POST /metadata/workflow is not
-            // honored by plain OSS Conductor, confirmed empirically (it still
-            // rejects an existing name+version instead of overwriting); the
-            // updateWorkflowDefs(..., true) call above already re-established
-            // the intended definition.
-            if (e.getStatus() != 500 || !e.getMessage().contains("already exists")) {
-                throw e;
-            }
-        }
+        // Both Orkes Enterprise and plain OSS Conductor honor overwrite=true on an existing
+        // name+version and succeed outright (verified empirically against a freshly-pulled
+        // OSS image; an earlier assumption that OSS rejected this with a 500 no longer holds).
+        metadataClient.registerWorkflowDef(workflowDef, true);
         ((OrkesMetadataClient) metadataClient)
                 .getWorkflowDefWithMetadata(Commons.WORKFLOW_NAME, Commons.WORKFLOW_VERSION);
         WorkflowDef receivedWorkflowDef = metadataClient.getWorkflowDef(Commons.WORKFLOW_NAME,

--- a/tests/src/test/java/io/orkes/conductor/client/http/MetadataClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/MetadataClientTests.java
@@ -61,17 +61,7 @@ public class MetadataClientTests {
         }
         metadataClient.registerTaskDefs(List.of(Commons.getTaskDef()));
         WorkflowDef workflowDef = WorkflowUtil.getWorkflowDef();
-        try {
-            metadataClient.registerWorkflowDef(workflowDef);
-        } catch (ConductorClientException e) {
-            // Commons.WORKFLOW_NAME/VERSION is shared fixture data used by several
-            // test classes in this suite; tolerate an "already exists" collision
-            // here since the update/overwrite calls below re-establish the
-            // intended definition regardless of which class registered it first.
-            if (e.getStatus() != 500 || !e.getMessage().contains("already exists")) {
-                throw e;
-            }
-        }
+        metadataClient.registerWorkflowDef(workflowDef);
         metadataClient.updateWorkflowDefs(List.of(workflowDef));
         metadataClient.updateWorkflowDefs(List.of(workflowDef), true);
         // Both Orkes Enterprise and plain OSS Conductor honor overwrite=true on an existing

--- a/tests/src/test/java/io/orkes/conductor/client/http/MetadataClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/MetadataClientTests.java
@@ -64,9 +64,6 @@ public class MetadataClientTests {
         metadataClient.registerWorkflowDef(workflowDef);
         metadataClient.updateWorkflowDefs(List.of(workflowDef));
         metadataClient.updateWorkflowDefs(List.of(workflowDef), true);
-        // Both Orkes Enterprise and plain OSS Conductor honor overwrite=true on an existing
-        // name+version and succeed outright (verified empirically against a freshly-pulled
-        // OSS image; an earlier assumption that OSS rejected this with a 500 no longer holds).
         metadataClient.registerWorkflowDef(workflowDef, true);
         ((OrkesMetadataClient) metadataClient)
                 .getWorkflowDefWithMetadata(Commons.WORKFLOW_NAME, Commons.WORKFLOW_VERSION);

--- a/tests/src/test/java/io/orkes/conductor/client/http/PromptClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/PromptClientTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
 
@@ -32,6 +33,8 @@ import io.orkes.conductor.client.model.integration.IntegrationUpdate;
 import org.conductoross.conductor.client.model.ai.PromptTemplate;
 import io.orkes.conductor.client.util.ClientTestUtil;
 
+@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+        disabledReason = "the Prompts and Integrations APIs (/prompts, /integrations) are not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/prompts|integrations/...')")
 public class PromptClientTests {
     private static final String PROMPT_NAME = "test-sdk-java-prompt";
     private static final String PROMPT_DESCRIPTION = "Test prompt for Java SDK";

--- a/tests/src/test/java/io/orkes/conductor/client/http/SchedulerClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/SchedulerClientTests.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.common.model.BulkResponse;
 
@@ -51,6 +52,10 @@ public class SchedulerClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "GET /scheduler/search does not 404 on plain OSS Conductor, but confirmed empirically to " +
+                    "always return zero results (even after polling for 30s) -- schedules aren't surfaced via search " +
+                    "on plain OSS the way they are on Orkes Enterprise")
     void testMethods() {
         schedulerClient.deleteSchedule(SCHEDULE_1);
         Assertions.assertTrue(schedulerClient.getNextFewSchedules(CRON_EXPRESSION_1, 0L, 0L, 0).isEmpty());

--- a/tests/src/test/java/io/orkes/conductor/client/http/SchemaClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/SchemaClientTests.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
 import com.netflix.conductor.common.metadata.SchemaDef;
@@ -24,6 +25,8 @@ import com.netflix.conductor.common.metadata.SchemaDef;
 import io.orkes.conductor.client.SchemaClient;
 import io.orkes.conductor.client.util.ClientTestUtil;
 
+@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+        disabledReason = "the Schema API (/schema) is not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/schema')")
 public class SchemaClientTests {
 
     private static final String SCHEMA_NAME = "test-sdk-java-schema";

--- a/tests/src/test/java/io/orkes/conductor/client/http/SecretClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/SecretClientTests.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
 
@@ -24,6 +25,8 @@ import io.orkes.conductor.client.model.TagObject;
 import io.orkes.conductor.client.util.ClientTestUtil;
 
 
+@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+        disabledReason = "secret writes are not supported by plain OSS Conductor, confirmed empirically: its env-var-backed secrets DAO is read-only, so putSecret() 501s ('env-backed secrets are read-only')")
 public class SecretClientTests {
     private final String SECRET_NAME = "test-sdk-java-secret_name";
     private final String SECRET_KEY = "test-sdk-java-secret_key";

--- a/tests/src/test/java/io/orkes/conductor/client/http/ServiceRegistryClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/ServiceRegistryClientTests.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
 import com.netflix.conductor.common.model.CircuitBreakerTransitionResponse;
@@ -32,6 +33,8 @@ import lombok.SneakyThrows;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+        disabledReason = "the Service Registry API (/registry/service) is not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/registry/service')")
 public class ServiceRegistryClientTests {
     private static final String SERVICE_NAME = "test-sdk-java-service";
     private static final String SERVICE_URI = "localhost:50051";

--- a/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.testcontainers.shaded.com.google.common.util.concurrent.Uninterruptibles;
 
@@ -146,6 +147,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the sync task-update endpoint (POST /tasks/{workflowId}/{taskRefName}/{status}/sync) never returns the updated workflow on plain OSS Conductor, confirmed empirically (caller times out waiting for terminal status)")
     public void testUpdateByRefNameSync() {
         StartWorkflowRequest request = new StartWorkflowRequest();
         request.setName(workflowName);
@@ -331,6 +334,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the SYNCHRONOUS/REGION_DURABLE consistency + BLOCKING_* return-strategy signal API (POST /tasks/{workflowId}/{status}/signal/sync) is not implemented by plain OSS Conductor, confirmed empirically")
     void testSyncTargetWorkflow() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.SYNCHRONOUS, ReturnStrategy.TARGET_WORKFLOW);
 
@@ -345,6 +350,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the SYNCHRONOUS/REGION_DURABLE consistency + BLOCKING_* return-strategy signal API (POST /tasks/{workflowId}/{status}/signal/sync) is not implemented by plain OSS Conductor, confirmed empirically")
     void testSyncBlockingWorkflow() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.SYNCHRONOUS, ReturnStrategy.BLOCKING_WORKFLOW);
 
@@ -359,6 +366,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the SYNCHRONOUS/REGION_DURABLE consistency + BLOCKING_* return-strategy signal API (POST /tasks/{workflowId}/{status}/signal/sync) is not implemented by plain OSS Conductor, confirmed empirically")
     void testSyncBlockingTask() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.SYNCHRONOUS, ReturnStrategy.BLOCKING_TASK);
 
@@ -373,6 +382,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the SYNCHRONOUS/REGION_DURABLE consistency + BLOCKING_* return-strategy signal API (POST /tasks/{workflowId}/{status}/signal/sync) is not implemented by plain OSS Conductor, confirmed empirically")
     void testSyncBlockingTaskInput() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.SYNCHRONOUS, ReturnStrategy.BLOCKING_TASK_INPUT);
 
@@ -390,7 +401,10 @@ public class TaskClientTests {
     private static final String REGION_DURABLE_ENABLED = "CONDUCTOR_REGION_DURABLE_ENABLED";
 
     @Test
-    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true")
+    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true",
+            disabledReason = "target server has no region replication configured")
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the SYNCHRONOUS/REGION_DURABLE consistency + BLOCKING_* return-strategy signal API (POST /tasks/{workflowId}/{status}/signal/sync) is not implemented by plain OSS Conductor, confirmed empirically")
     void testDurableTargetWorkflow() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.REGION_DURABLE, ReturnStrategy.TARGET_WORKFLOW);
 
@@ -405,7 +419,10 @@ public class TaskClientTests {
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true")
+    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true",
+            disabledReason = "target server has no region replication configured")
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the SYNCHRONOUS/REGION_DURABLE consistency + BLOCKING_* return-strategy signal API (POST /tasks/{workflowId}/{status}/signal/sync) is not implemented by plain OSS Conductor, confirmed empirically")
     void testDurableBlockingWorkflow() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.REGION_DURABLE, ReturnStrategy.BLOCKING_WORKFLOW);
 
@@ -420,6 +437,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the SYNCHRONOUS/REGION_DURABLE consistency + BLOCKING_* return-strategy signal API (POST /tasks/{workflowId}/{status}/signal/sync) is not implemented by plain OSS Conductor, confirmed empirically")
     void testDurableBlockingTask() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.DURABLE, ReturnStrategy.BLOCKING_TASK);
 
@@ -434,7 +453,10 @@ public class TaskClientTests {
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true")
+    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true",
+            disabledReason = "target server has no region replication configured")
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the SYNCHRONOUS/REGION_DURABLE consistency + BLOCKING_* return-strategy signal API (POST /tasks/{workflowId}/{status}/signal/sync) is not implemented by plain OSS Conductor, confirmed empirically")
     void testDurableBlockingTaskInput() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.REGION_DURABLE, ReturnStrategy.BLOCKING_TASK_INPUT);
 
@@ -449,6 +471,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "the SYNCHRONOUS/REGION_DURABLE consistency + BLOCKING_* return-strategy signal API (POST /tasks/{workflowId}/{status}/signal/sync) is not implemented by plain OSS Conductor, confirmed empirically")
     void testDefaultReturnStrategy() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.SYNCHRONOUS, ReturnStrategy.TARGET_WORKFLOW);
 
@@ -727,6 +751,8 @@ public class TaskClientTests {
     // ==================== Search Tests ====================
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "GET /tasks/search fails on plain OSS Conductor with a Postgres persistence layer, confirmed empirically (ERROR: column \"workflow_id\" does not exist)")
     void testSearchTasks() {
         StartWorkflowRequest request = new StartWorkflowRequest();
         request.setName(workflowName);
@@ -763,6 +789,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "GET /tasks/search fails on plain OSS Conductor with a Postgres persistence layer, confirmed empirically (ERROR: column \"workflow_id\" does not exist)")
     void testPaginatedSearchTasks() {
         StartWorkflowRequest request = new StartWorkflowRequest();
         request.setName(workflowName);

--- a/tests/src/test/java/io/orkes/conductor/client/http/TokenClientTest.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/TokenClientTest.java
@@ -16,11 +16,14 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import io.orkes.conductor.client.model.GenerateTokenRequest;
 import io.orkes.conductor.client.model.TokenResponse;
 import io.orkes.conductor.client.util.ClientTestUtil;
 
+@DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+        disabledReason = "the auth Token API (/token) is not implemented by plain OSS Conductor (which has no authentication layer), confirmed empirically (404 'No static resource api/token')")
 public class TokenClientTest {
 
     public static OrkesTokenClient tokenClient;

--- a/tests/src/test/java/io/orkes/conductor/client/http/WorkflowClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/WorkflowClientTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
@@ -102,6 +103,8 @@ public class WorkflowClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "batch correlation-id search (POST /workflow/correlated/batch) is not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/workflow/correlated/batch')")
     public void testSearchByCorrelationIds() {
         List<String> correlationIds = new ArrayList<>();
         Set<String> workflowNames = new HashSet<>();
@@ -188,6 +191,8 @@ public class WorkflowClientTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "POST /workflow/{workflowId}/variables is not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/workflow/{id}/variables')")
     public void testUpdateVariables() {
         ConductorWorkflow<Object> workflow = new ConductorWorkflow<>(workflowExecutor);
         workflow.add(new SimpleTask("simple_task", "simple_task_ref"));

--- a/tests/src/test/java/io/orkes/conductor/client/http/WorkflowStateUpdateTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/WorkflowStateUpdateTests.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.conductoross.conductor.common.model.WorkflowRun;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
 import com.netflix.conductor.common.metadata.tasks.Task;
@@ -91,6 +92,8 @@ public class WorkflowStateUpdateTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "POST /workflow/{workflowId}/state (updateWorkflow) is not implemented by plain OSS Conductor, confirmed empirically (404 'No static resource api/workflow/{id}/state')")
     public void test() {
         String workflowId = startWorkflow();
         System.out.println(workflowId);
@@ -135,6 +138,8 @@ public class WorkflowStateUpdateTests {
     }
 
     @Test
+    @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss",
+            disabledReason = "workflow start idempotency keys are not honored by plain OSS Conductor, confirmed empirically (RETURN_EXISTING starts a brand-new run instead of returning the original workflowId)")
     public void testIdempotency() {
         StartWorkflowRequest startWorkflowRequest = new StartWorkflowRequest();
         startWorkflowRequest.setName("sync_task_variable_updates");

--- a/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
+++ b/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
@@ -163,29 +163,24 @@ public class TestUtil {
     }
 
     /**
-     * Whether the suite is currently running against plain OSS Conductor rather than Orkes
-     * Enterprise, per the same {@code CONDUCTOR_SERVER_TYPE} signal that
-     * {@code @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss")}
-     * checks for test gating.
-     */
-    public static boolean isOssServer() {
-        return "oss".equals(System.getenv("CONDUCTOR_SERVER_TYPE"));
-    }
-
-    /**
-     * Asserts a caught exception represents "resource doesn't exist", in the shape specific to
-     * whichever server type {@code CONDUCTOR_SERVER_TYPE} says we're running against: Orkes
-     * Enterprise reports a proper 404; plain OSS Conductor instead reports a 500 whose message
-     * contains {@code ossMessageSubstring} (empirically confirmed per endpoint). Anything else
-     * is rethrown, since it isn't the "doesn't exist" case this is meant to tolerate.
+     * Tolerates a caught exception that represents "resource doesn't exist", in either shape a
+     * Conductor server reports it in: a proper 404, or -- on plain OSS Conductor, for the
+     * endpoints where this has been empirically confirmed -- a 500 whose message contains
+     * {@code ossMessageSubstring}. Anything else is rethrown, since it isn't the "doesn't exist"
+     * case this is meant to tolerate.
+     *
+     * <p>Both shapes are accepted regardless of {@code CONDUCTOR_SERVER_TYPE}. Keying off that
+     * variable would break two ways: {@code run-integration-oss.sh --include-gated} runs against
+     * OSS with it deliberately unset, and OSS returning a correct 404 for one of these endpoints
+     * should not start failing the suite.
      */
     public static void assertNotFoundOrRethrow(ConductorClientException e, String ossMessageSubstring) {
-        if (isOssServer()) {
-            if (e.getStatus() != 500 || e.getMessage() == null || !e.getMessage().contains(ossMessageSubstring)) {
-                throw e;
-            }
-        } else if (e.getStatus() != 404) {
-            throw e;
+        if (e.getStatus() == 404) {
+            return;
         }
+        if (e.getStatus() == 500 && e.getMessage() != null && e.getMessage().contains(ossMessageSubstring)) {
+            return;
+        }
+        throw e;
     }
 }

--- a/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
+++ b/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
@@ -18,6 +18,7 @@ import java.io.InputStreamReader;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
@@ -159,5 +160,29 @@ public class TestUtil {
     private static boolean isTerminalFailure(Workflow workflow) {
         return workflow.getStatus() == Workflow.WorkflowStatus.FAILED
                 || workflow.getStatus() == Workflow.WorkflowStatus.TERMINATED;
+    }
+
+    /**
+     * Repeatedly invokes {@code supplier} until {@code condition} accepts its result, or the
+     * time budget is exhausted, sleeping {@code pollIntervalMs} between attempts. Useful for
+     * assertions against eventually-consistent state (e.g. search-index writes) instead of a
+     * single point-in-time check.
+     *
+     * @return the first result accepted by {@code condition}
+     * @throws TimeoutException if no result satisfies {@code condition} within maxWaitTimeMs
+     */
+    public static <T> T waitUntil(Callable<T> supplier, Predicate<T> condition,
+                                   long maxWaitTimeMs, long pollIntervalMs) throws Exception {
+        long endTime = System.currentTimeMillis() + maxWaitTimeMs;
+        T last = supplier.call();
+        while (!condition.test(last)) {
+            if (System.currentTimeMillis() >= endTime) {
+                throw new TimeoutException(
+                        String.format("Condition not met within %dms. Last value: %s", maxWaitTimeMs, last));
+            }
+            Thread.sleep(pollIntervalMs);
+            last = supplier.call();
+        }
+        return last;
     }
 }

--- a/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
+++ b/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
@@ -18,7 +18,6 @@ import java.io.InputStreamReader;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Predicate;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
 import com.netflix.conductor.common.config.ObjectMapperProvider;
@@ -161,30 +160,6 @@ public class TestUtil {
     private static boolean isTerminalFailure(Workflow workflow) {
         return workflow.getStatus() == Workflow.WorkflowStatus.FAILED
                 || workflow.getStatus() == Workflow.WorkflowStatus.TERMINATED;
-    }
-
-    /**
-     * Repeatedly invokes {@code supplier} until {@code condition} accepts its result, or the
-     * time budget is exhausted, sleeping {@code pollIntervalMs} between attempts. Useful for
-     * assertions against eventually-consistent state (e.g. search-index writes) instead of a
-     * single point-in-time check.
-     *
-     * @return the first result accepted by {@code condition}
-     * @throws TimeoutException if no result satisfies {@code condition} within maxWaitTimeMs
-     */
-    public static <T> T waitUntil(Callable<T> supplier, Predicate<T> condition,
-                                   long maxWaitTimeMs, long pollIntervalMs) throws Exception {
-        long endTime = System.currentTimeMillis() + maxWaitTimeMs;
-        T last = supplier.call();
-        while (!condition.test(last)) {
-            if (System.currentTimeMillis() >= endTime) {
-                throw new TimeoutException(
-                        String.format("Condition not met within %dms. Last value: %s", maxWaitTimeMs, last));
-            }
-            Thread.sleep(pollIntervalMs);
-            last = supplier.call();
-        }
-        return last;
     }
 
     /**

--- a/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
+++ b/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 
+import com.netflix.conductor.client.exception.ConductorClientException;
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.run.Workflow;
@@ -184,5 +185,32 @@ public class TestUtil {
             last = supplier.call();
         }
         return last;
+    }
+
+    /**
+     * Whether the suite is currently running against plain OSS Conductor rather than Orkes
+     * Enterprise, per the same {@code CONDUCTOR_SERVER_TYPE} signal that
+     * {@code @DisabledIfEnvironmentVariable(named = "CONDUCTOR_SERVER_TYPE", matches = "oss")}
+     * checks for test gating.
+     */
+    public static boolean isOssServer() {
+        return "oss".equals(System.getenv("CONDUCTOR_SERVER_TYPE"));
+    }
+
+    /**
+     * Asserts a caught exception represents "resource doesn't exist", in the shape specific to
+     * whichever server type {@code CONDUCTOR_SERVER_TYPE} says we're running against: Orkes
+     * Enterprise reports a proper 404; plain OSS Conductor instead reports a 500 whose message
+     * contains {@code ossMessageSubstring} (empirically confirmed per endpoint). Anything else
+     * is rethrown, since it isn't the "doesn't exist" case this is meant to tolerate.
+     */
+    public static void assertNotFoundOrRethrow(ConductorClientException e, String ossMessageSubstring) {
+        if (isOssServer()) {
+            if (e.getStatus() != 500 || e.getMessage() == null || !e.getMessage().contains(ossMessageSubstring)) {
+                throw e;
+            }
+        } else if (e.getStatus() != 404) {
+            throw e;
+        }
     }
 }

--- a/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
+++ b/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
@@ -40,8 +40,8 @@ public class WorkflowSDKTests {
         ConductorClient client = ClientTestUtil.getClient();
 
         AnnotatedWorkerExecutor workerExecutor = new AnnotatedWorkerExecutor(new TaskClient(client), new WorkerConfiguration());
+        // initWorkers() already starts polling; a redundant extra startPolling() call here used to race with AnnotatedWorkerExecutor's own double-start (likely a real bug there) and could drop the first polled task.
         workerExecutor.initWorkers("io.orkes.conductor.sdk");
-        workerExecutor.startPolling();
 
         WorkflowExecutor executor = new WorkflowExecutor(client, workerExecutor);
 

--- a/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
+++ b/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
@@ -14,9 +14,6 @@ package io.orkes.conductor.sdk;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,12 +30,13 @@ import com.netflix.conductor.sdk.workflow.task.InputParam;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
 
 import io.orkes.conductor.client.util.ClientTestUtil;
+import io.orkes.conductor.client.util.TestUtil;
 
 
 public class WorkflowSDKTests {
 
     @Test
-    public void testCreateWorkflow() {
+    public void testCreateWorkflow() throws Exception {
         ConductorClient client = ClientTestUtil.getClient();
 
         AnnotatedWorkerExecutor workerExecutor = new AnnotatedWorkerExecutor(new TaskClient(client), new WorkerConfiguration());
@@ -57,10 +55,14 @@ public class WorkflowSDKTests {
         CompletableFuture<Workflow> result = workflow.execute(Map.of("name", "orkes"));
         Assertions.assertNotNull(result);
         try {
-            Workflow executedWorkflow = result.get(3, TimeUnit.SECONDS);
+            // Poll with a time budget instead of a single point-in-time get(): worker
+            // registration + polling + task execution can take longer than a couple of
+            // seconds under load (e.g. running alongside the rest of the integration suite).
+            TestUtil.waitUntil(result::isDone, Boolean::booleanValue, 30_000, 3_000);
+            Workflow executedWorkflow = result.get();
             Assertions.assertNotNull(executedWorkflow);
             Assertions.assertEquals(Workflow.WorkflowStatus.COMPLETED, executedWorkflow.getStatus());
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (Exception e) {
             Assertions.fail(e.getMessage());
         }
     }

--- a/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
+++ b/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
@@ -57,8 +57,9 @@ public class WorkflowSDKTests {
         try {
             // Poll with a time budget instead of a single point-in-time get(): worker
             // registration + polling + task execution can take longer than a couple of
-            // seconds under load (e.g. running alongside the rest of the integration suite).
-            TestUtil.waitUntil(result::isDone, Boolean::booleanValue, 30_000, 3_000);
+            // seconds under load (e.g. running alongside the rest of the integration suite,
+            // or on a shared/slower CI runner -- 30s was observed to be marginal in CI).
+            TestUtil.waitUntil(result::isDone, Boolean::booleanValue, 60_000, 3_000);
             Workflow executedWorkflow = result.get();
             Assertions.assertNotNull(executedWorkflow);
             Assertions.assertEquals(Workflow.WorkflowStatus.COMPLETED, executedWorkflow.getStatus());

--- a/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
+++ b/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
@@ -14,6 +14,7 @@ package io.orkes.conductor.sdk;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,6 @@ import com.netflix.conductor.sdk.workflow.task.InputParam;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
 
 import io.orkes.conductor.client.util.ClientTestUtil;
-import io.orkes.conductor.client.util.TestUtil;
 
 
 public class WorkflowSDKTests {
@@ -55,12 +55,8 @@ public class WorkflowSDKTests {
         CompletableFuture<Workflow> result = workflow.execute(Map.of("name", "orkes"));
         Assertions.assertNotNull(result);
         try {
-            // Poll with a time budget instead of a single point-in-time get(): worker
-            // registration + polling + task execution can take longer than a couple of
-            // seconds under load (e.g. running alongside the rest of the integration suite,
-            // or on a shared/slower CI runner -- 30s was observed to be marginal in CI).
-            TestUtil.waitUntil(result::isDone, Boolean::booleanValue, 60_000, 3_000);
-            Workflow executedWorkflow = result.get();
+            // WorkflowExecutor's monitor thread polls every 100ms (see initMonitor()), so 10s is a generous margin.
+            Workflow executedWorkflow = result.get(10, TimeUnit.SECONDS);
             Assertions.assertNotNull(executedWorkflow);
             Assertions.assertEquals(Workflow.WorkflowStatus.COMPLETED, executedWorkflow.getStatus());
         } catch (Exception e) {

--- a/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
+++ b/tests/src/test/java/io/orkes/conductor/sdk/WorkflowSDKTests.java
@@ -40,8 +40,12 @@ public class WorkflowSDKTests {
         ConductorClient client = ClientTestUtil.getClient();
 
         AnnotatedWorkerExecutor workerExecutor = new AnnotatedWorkerExecutor(new TaskClient(client), new WorkerConfiguration());
-        // initWorkers() already starts polling; a redundant extra startPolling() call here used to race with AnnotatedWorkerExecutor's own double-start (likely a real bug there) and could drop the first polled task.
         workerExecutor.initWorkers("io.orkes.conductor.sdk");
+        // Redundant -- initWorkers() already reaches startPolling() -- but kept deliberately: this is
+        // the shape the docs and examples use, and startPolling() is now idempotent, so it must not
+        // restart the runner out from under an in-flight poll. See
+        // AnnotatedWorkerTests#initWorkersStartsASingleTaskRunner.
+        workerExecutor.startPolling();
 
         WorkflowExecutor executor = new WorkflowExecutor(client, workerExecutor);
 
@@ -60,7 +64,9 @@ public class WorkflowSDKTests {
             Assertions.assertNotNull(executedWorkflow);
             Assertions.assertEquals(Workflow.WorkflowStatus.COMPLETED, executedWorkflow.getStatus());
         } catch (Exception e) {
-            Assertions.fail(e.getMessage());
+            // fail(e), not fail(e.getMessage()): a TimeoutException carries a null message, which
+            // previously surfaced in CI as a bare AssertionFailedError with nothing to diagnose.
+            Assertions.fail(e);
         }
     }
 


### PR DESCRIPTION
Pull Request type
----
- [x] Build related changes
- [x] Bugfix

Changes in this PR
----

Added an integration test run against an org-pinned Conductor OSS server, as a second job in `integration-tests.yml`.

`scripts/run-integration-oss.sh` reproduces the CI job locally (see CONTRIBUTING.md). Tests OSS can't serve are gated with `@DisabledIfEnvironmentVariable(CONDUCTOR_SERVER_TYPE=oss)`, each carrying its specific reason — 53 of 106 skip today.

⚠️ Contains a temporary branch-scoped `push:` trigger so the new job can run pre-merge. Remove before merging — it's fenced in a comment.

Getting that suite green turned up two real client bugs, both fixed here:

- **`AnnotatedWorkerExecutor.startPolling()` is now idempotent.** It stood up a replacement `TaskRunnerConfigurer` and shut the old one down *after* starting the new one, so a double call left two runners polling the same task types and could strand a task the outgoing runner had already leased. `initWorkers()` called it twice on its own. It's now a no-op unless workers were added since the last start. `shutdown()` clears the runner so a later restart still works, and `addBean()` is synchronized so the flag it sets is safely published.
- **`WorkflowExecutor`'s completion monitor no longer dies on a transient error.** It runs under `scheduleAtFixedRate`, so a single failed `getWorkflow` permanently killed completion tracking for every workflow. Now caught and warned once, then retried indefinitely — `setMonitorFailureGiveUpMillis()` opts into a bounded budget that fails the future instead.

Seven unit tests cover both fixes (`AnnotatedWorkerTests`, `WorkflowExecutorMonitorTests`).