### PR TITLE
ci: link Integration Tests status to its run

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,6 +56,7 @@ jobs:
               owner, repo, sha,
               state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
               context: 'Integration Tests',
+              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
               description: 'Integration tests ${{ job.status }}'
             });
 


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
It is a simple change to render the missing link for `Integration Tests — Integration tests failure` on the PR

- Add target_url so the PR status row gets a Details link


Alternatives considered
----

None