### PR TITLE
fix: unique root agent names in examples

### DIFF
--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example02Tools.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example02Tools.java
@@ -48,7 +48,7 @@ public class Example02Tools {
         List<ToolDef> tools = ToolRegistry.fromInstance(new AgentTools());
 
         Agent agent = Agent.builder()
-            .name("weather_stock_agent")
+            .name("weather_stock_agent_02")
             .model(Settings.LLM_MODEL)
             .tools(tools)
             .instructions("You are a helpful assistant. Use tools to answer questions.")

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example02aSimpleTools.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example02aSimpleTools.java
@@ -50,7 +50,7 @@ public class Example02aSimpleTools {
         List<ToolDef> tools = ToolRegistry.fromInstance(new AssistantTools());
 
         Agent agent = Agent.builder()
-            .name("weather_stock_agent")
+            .name("weather_stock_agent_02a")
             .model(Settings.LLM_MODEL)
             .tools(tools)
             .instructions("You are a helpful assistant. Use tools to answer questions.")

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example05Handoffs.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example05Handoffs.java
@@ -82,7 +82,7 @@ public class Example05Handoffs {
 
         // Orchestrator with handoff strategy
         Agent support = Agent.builder()
-            .name("support")
+            .name("support_05")
             .model(Settings.LLM_MODEL)
             .instructions("Route customer requests to the right specialist: billing, technical, or sales.")
             .agents(billingAgent, technicalAgent, salesAgent)

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example09bHandoffHumanInTheLoop.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example09bHandoffHumanInTheLoop.java
@@ -65,7 +65,7 @@ public class Example09bHandoffHumanInTheLoop {
             .build();
 
         Agent support = Agent.builder()
-            .name("support")
+            .name("support_09b")
             .model(Settings.LLM_MODEL)
             .instructions("Route any database task to the dba sub-agent.")
             .agents(dba)

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example10Guardrails.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example10Guardrails.java
@@ -86,7 +86,7 @@ public class Example10Guardrails {
             ToolRegistry.guardrailsFromInstance(new PiiGuardrails());
 
         Agent agent = Agent.builder()
-            .name("support_agent")
+            .name("support_agent_10")
             .model(Settings.LLM_MODEL)
             .instructions(
                 "You are a customer support assistant. Use the available tools to "

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example17SwarmOrchestration.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example17SwarmOrchestration.java
@@ -57,7 +57,7 @@ public class Example17SwarmOrchestration {
         // ── Front-line support with SWARM strategy ───────────────────────
 
         Agent support = Agent.builder()
-            .name("support")
+            .name("support_17")
             .model(Settings.LLM_MODEL)
             .instructions(
                 "You are the front-line customer support agent. Triage customer requests. "

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example42SecurityTesting.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example42SecurityTesting.java
@@ -117,7 +117,7 @@ public class Example42SecurityTesting {
 
         // Pipeline: attack → respond → evaluate
         Agent pipeline = Agent.builder()
-            .name("security_test_pipeline")
+            .name("security_test_pipeline_42")
             .model(Settings.LLM_MODEL)
             .agents(redTeam, target, evaluator)
             .strategy(Strategy.SEQUENTIAL)

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example55MlEngineeringPipeline.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example55MlEngineeringPipeline.java
@@ -129,7 +129,7 @@ public class Example55MlEngineeringPipeline {
         // ── Full pipeline (flat 8-agent sequential list) ───────────────────
 
         Agent mlPipeline = Agent.builder()
-            .name("ml_pipeline")
+            .name("ml_pipeline_55")
             .model(Settings.LLM_MODEL)
             .agents(dataAnalyst, modelExploration, evaluator,
                     optimizerR1, validatorR1, optimizerR2, validatorR2,

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example58ScatterGather.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example58ScatterGather.java
@@ -130,7 +130,7 @@ public class Example58ScatterGather {
             + "countries by GDP.";
 
         Agent coordinator = Agent.builder()
-            .name("coordinator")
+            .name("coordinator_58")
             .model(Settings.SECONDARY_LLM_MODEL)
             .instructions(instructions)
             .tools(List.of(workerTool))

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example65ParallelWithTools.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example65ParallelWithTools.java
@@ -87,7 +87,7 @@ public class Example65ParallelWithTools {
 
         // Both analysts run concurrently
         Agent analysis = Agent.builder()
-            .name("parallel_analysis")
+            .name("parallel_analysis_65")
             .model(Settings.LLM_MODEL)
             .agents(financialAnalyst, orderAnalyst)
             .strategy(Strategy.PARALLEL)

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example00HelloWorld.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example00HelloWorld.java
@@ -35,7 +35,7 @@ public class Example00HelloWorld {
     public static void main(String[] args) {
         AgentRuntime runtime = new AgentRuntime();
         LlmAgent greeter = LlmAgent.builder()
-                .name("greeter")
+                .name("adk_greeter_00")
                 .description("A friendly greeter that says hello and shares a fun fact.")
                 .model(Settings.LLM_MODEL)
                 .instruction("You are a friendly greeter. Reply with a warm hello and one fun fact.")

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example01BasicAgent.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example01BasicAgent.java
@@ -31,7 +31,7 @@ public class Example01BasicAgent {
     public static void main(String[] args) {
         AgentRuntime runtime = new AgentRuntime();
         LlmAgent researcher = LlmAgent.builder()
-            .name("greeter")
+            .name("adk_greeter_01")
             .description("A friendly assistant that gives concise, helpful answers.")
             .model(Settings.LLM_MODEL)
             .instruction("You are a friendly assistant. Keep your responses concise and helpful.")

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example09MultiToolAgent.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example09MultiToolAgent.java
@@ -133,7 +133,7 @@ public class Example09MultiToolAgent {
     public static void main(String[] args) {
         AgentRuntime runtime = new AgentRuntime();
         LlmAgent shopper = LlmAgent.builder()
-            .name("shopping_assistant")
+            .name("adk_shopping_assistant_09")
             .description("Helps users search products, check stock, calculate shipping, and apply coupons.")
             .model(Settings.LLM_MODEL)
             .instruction("""

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example12ParallelAgent.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example12ParallelAgent.java
@@ -62,7 +62,7 @@ public class Example12ParallelAgent {
 
         // All three analysts dispatched concurrently by native ParallelAgent.
         ParallelAgent parallelAnalysis = ParallelAgent.builder()
-            .name("parallel_analysis")
+            .name("adk_parallel_analysis_12")
             .description("Fan-out to three analysts running in parallel.")
             .subAgents(marketAnalyst, techAnalyst, riskAnalyst)
             .build();

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example27SecurityAgent.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example27SecurityAgent.java
@@ -119,7 +119,7 @@ public class Example27SecurityAgent {
             .build();
 
         LlmAgent securityTest = LlmAgent.builder()
-            .name("security_test_pipeline")
+            .name("adk_security_test_pipeline_27")
             .description("Sequential pipeline: red-team → target → security evaluator.")
             .model(Settings.LLM_MODEL)
             .instruction("""

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example29IncludeContents.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example29IncludeContents.java
@@ -49,7 +49,7 @@ public class Example29IncludeContents {
             .build();
 
         LlmAgent coordinator = LlmAgent.builder()
-            .name("coordinator")
+            .name("adk_coordinator_29")
             .description("Routes summarization to the independent summarizer and questions to the helper.")
             .model(Settings.LLM_MODEL)
             .instruction(

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example31SharedState.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example31SharedState.java
@@ -59,7 +59,7 @@ public class Example31SharedState {
     public static void main(String[] args) {
         AgentRuntime runtime = new AgentRuntime();
         LlmAgent stateAgent = LlmAgent.builder()
-            .name("shopping_assistant")
+            .name("adk_shopping_assistant_31")
             .description("Manages a shopping list shared across tool calls via add/get/clear tools.")
             .model(Settings.LLM_MODEL)
             .instruction(

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example34MlEngineering.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/adk/Example34MlEngineering.java
@@ -197,7 +197,7 @@ public class Example34MlEngineering {
 
         // ── Full Pipeline ────────────────────────────────────────────────
         LlmAgent mlPipeline = LlmAgent.builder()
-            .name("ml_pipeline")
+            .name("adk_ml_pipeline_34")
             .description("End-to-end ML pipeline orchestrating EDA, exploration, evaluation, refinement, and reporting.")
             .model(Settings.LLM_MODEL)
             .instruction("""

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/openai/Example01BasicAgent.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/openai/Example01BasicAgent.java
@@ -39,7 +39,7 @@ public class Example01BasicAgent {
     public static void main(String[] args) {
         AgentRuntime runtime = new AgentRuntime();
         Agent agent = OpenAIAgent.builder()
-                .name("greeter")
+                .name("openai_greeter_01")
                 .instructions("You are a friendly assistant. Keep your responses concise and helpful.")
                 .model(Settings.LLM_MODEL)
                 .build();

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/openai/Example07Streaming.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/openai/Example07Streaming.java
@@ -68,7 +68,7 @@ public class Example07Streaming {
     public static void main(String[] args) {
         AgentRuntime runtime = new AgentRuntime();
         Agent agent = OpenAIAgent.builder()
-                .name("support_agent")
+                .name("openai_support_agent_07")
                 .instructions(
                         "You are a customer support agent. Use the knowledge base to answer "
                                 + "questions accurately. If you can't find the answer, say so honestly.")


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe): Improve examples

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- 20 examples renamed off 9 shared names, package prefix outside root
- langchain_agent and langgraph_agent still shared, hardcoded in the runtime

Alternatives considered
----

None