### PR TITLE
test: gate REGION_DURABLE cases and de-flake the integration suite

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${versions.junit}"
     testImplementation "ch.qos.logback:logback-classic:1.5.32"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.awaitility:awaitility:${versions.awaitility}"
     testImplementation "org.testcontainers:localstack:${versions.testContainers}"
     testImplementation "org.testcontainers:testcontainers:${versions.testContainers}"
 }

--- a/tests/src/test/java/io/orkes/conductor/client/ApiClientTest.java
+++ b/tests/src/test/java/io/orkes/conductor/client/ApiClientTest.java
@@ -30,7 +30,7 @@ import com.netflix.conductor.common.run.Workflow;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 
 public class ApiClientTest {
     private static final String workflowName = "test_api_client_wf";

--- a/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
@@ -484,8 +484,9 @@ public class TaskClientTests {
         assertNotNull(workflow);
         String workflowId = workflow.getWorkflowId();
 
-        // Wait for initial execution
-        Thread.sleep(20);
+        // Wait until the workflow actually has a task to signal. A fixed 20ms sleep raced the
+        // engine: signalling before the task existed left the workflow FAILED.
+        TestUtil.waitUntilSignalable(workflowClient, workflowId, 30_000, 100);
 
         // Signal with async execution
         taskClient.signalAsync(workflowId, Task.Status.COMPLETED, Map.of("result", "test"));
@@ -509,8 +510,9 @@ public class TaskClientTests {
         assertNotNull(workflow);
         String workflowId = workflow.getTargetWorkflowId();
 
-        // Wait for initial execution
-        Thread.sleep(20);
+        // Wait until the workflow actually has a task to signal. A fixed 20ms sleep raced the
+        // engine: signalling before the task existed left the workflow FAILED.
+        TestUtil.waitUntilSignalable(workflowClient, workflowId, 30_000, 100);
 
         // Signal with async execution
         taskClient.signalAsync(workflowId, Task.Status.COMPLETED, Map.of("result", "test"));
@@ -534,8 +536,9 @@ public class TaskClientTests {
         assertNotNull(workflow);
         String workflowId = workflow.getTargetWorkflowId();
 
-        // Wait for initial execution
-        Thread.sleep(20);
+        // Wait until the workflow actually has a task to signal. A fixed 20ms sleep raced the
+        // engine: signalling before the task existed left the workflow FAILED.
+        TestUtil.waitUntilSignalable(workflowClient, workflowId, 30_000, 100);
 
         // Signal with async execution
         taskClient.signalAsync(workflowId, Task.Status.COMPLETED, Map.of("result", "test"));
@@ -742,7 +745,7 @@ public class TaskClientTests {
     // ==================== Search Tests ====================
 
     @Test
-    void testSearchTasks() {
+    void testSearchTasks() throws Exception {
         StartWorkflowRequest request = new StartWorkflowRequest();
         request.setName(workflowName);
         request.setVersion(1);
@@ -750,9 +753,11 @@ public class TaskClientTests {
         String workflowId = workflowClient.startWorkflow(request);
 
         try {
-            Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
-
-            var result = taskClient.search("workflowId='" + workflowId + "'");
+            // Search is asynchronously indexed and occasionally slow to answer, so a single shot
+            // after a fixed sleep was doubly fragile — it raced indexing and died on a transient
+            // SocketTimeoutException. Retry until it responds.
+            var result = TestUtil.retryUntil(
+                    () -> taskClient.search("workflowId='" + workflowId + "'"), 30_000, 2_000);
             assertNotNull(result);
         } finally {
             workflowClient.terminateWorkflow(workflowId, "cleanup");

--- a/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
@@ -386,18 +386,11 @@ public class TaskClientTests {
         completeWorkflow(workflowId);
     }
 
-    /**
-     * REGION_DURABLE requires the target server to have cross-region replication configured.
-     * Since orkes-conductor 5.5.0 a node without it fails the start closed rather than silently
-     * downgrading to a local start, so these only run where the capability actually exists —
-     * set {@value #REGION_DURABLE_ENABLED}=true there. Opt-in rather than skip-on-error, so a
-     * genuine replication regression still fails loudly instead of quietly going green.
-     */
+    // Needs a server with cross-region replication configured.
     private static final String REGION_DURABLE_ENABLED = "CONDUCTOR_REGION_DURABLE_ENABLED";
 
     @Test
-    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true",
-            disabledReason = "target server has no region replication configured")
+    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true")
     void testDurableTargetWorkflow() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.REGION_DURABLE, ReturnStrategy.TARGET_WORKFLOW);
 
@@ -412,8 +405,7 @@ public class TaskClientTests {
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true",
-            disabledReason = "target server has no region replication configured")
+    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true")
     void testDurableBlockingWorkflow() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.REGION_DURABLE, ReturnStrategy.BLOCKING_WORKFLOW);
 
@@ -442,8 +434,7 @@ public class TaskClientTests {
     }
 
     @Test
-    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true",
-            disabledReason = "target server has no region replication configured")
+    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true")
     void testDurableBlockingTaskInput() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.REGION_DURABLE, ReturnStrategy.BLOCKING_TASK_INPUT);
 
@@ -484,11 +475,8 @@ public class TaskClientTests {
         assertNotNull(workflow);
         String workflowId = workflow.getWorkflowId();
 
-        // Wait until the workflow actually has a task to signal. A fixed 20ms sleep raced the
-        // engine: signalling before the task existed left the workflow FAILED.
         TestUtil.waitUntilSignalable(workflowClient, workflowId, 30_000, 100);
 
-        // Signal with async execution
         taskClient.signalAsync(workflowId, Task.Status.COMPLETED, Map.of("result", "test"));
 
         // Wait for completion
@@ -510,11 +498,8 @@ public class TaskClientTests {
         assertNotNull(workflow);
         String workflowId = workflow.getTargetWorkflowId();
 
-        // Wait until the workflow actually has a task to signal. A fixed 20ms sleep raced the
-        // engine: signalling before the task existed left the workflow FAILED.
         TestUtil.waitUntilSignalable(workflowClient, workflowId, 30_000, 100);
 
-        // Signal with async execution
         taskClient.signalAsync(workflowId, Task.Status.COMPLETED, Map.of("result", "test"));
 
         // Wait for completion
@@ -536,11 +521,8 @@ public class TaskClientTests {
         assertNotNull(workflow);
         String workflowId = workflow.getTargetWorkflowId();
 
-        // Wait until the workflow actually has a task to signal. A fixed 20ms sleep raced the
-        // engine: signalling before the task existed left the workflow FAILED.
         TestUtil.waitUntilSignalable(workflowClient, workflowId, 30_000, 100);
 
-        // Signal with async execution
         taskClient.signalAsync(workflowId, Task.Status.COMPLETED, Map.of("result", "test"));
 
         // Wait for completion
@@ -745,7 +727,7 @@ public class TaskClientTests {
     // ==================== Search Tests ====================
 
     @Test
-    void testSearchTasks() throws Exception {
+    void testSearchTasks() {
         StartWorkflowRequest request = new StartWorkflowRequest();
         request.setName(workflowName);
         request.setVersion(1);
@@ -753,9 +735,6 @@ public class TaskClientTests {
         String workflowId = workflowClient.startWorkflow(request);
 
         try {
-            // Search is asynchronously indexed and occasionally slow to answer, so a single shot
-            // after a fixed sleep was doubly fragile — it raced indexing and died on a transient
-            // SocketTimeoutException. Retry until it responds.
             var result = TestUtil.retryUntil(
                     () -> taskClient.search("workflowId='" + workflowId + "'"), 30_000, 2_000);
             assertNotNull(result);

--- a/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.testcontainers.shaded.com.google.common.util.concurrent.Uninterruptibles;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
@@ -385,8 +386,18 @@ public class TaskClientTests {
         completeWorkflow(workflowId);
     }
 
-    // Durable tests - just copy the above and change Consistency
+    /**
+     * REGION_DURABLE requires the target server to have cross-region replication configured.
+     * Since orkes-conductor 5.5.0 a node without it fails the start closed rather than silently
+     * downgrading to a local start, so these only run where the capability actually exists —
+     * set {@value #REGION_DURABLE_ENABLED}=true there. Opt-in rather than skip-on-error, so a
+     * genuine replication regression still fails loudly instead of quietly going green.
+     */
+    private static final String REGION_DURABLE_ENABLED = "CONDUCTOR_REGION_DURABLE_ENABLED";
+
     @Test
+    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true",
+            disabledReason = "target server has no region replication configured")
     void testDurableTargetWorkflow() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.REGION_DURABLE, ReturnStrategy.TARGET_WORKFLOW);
 
@@ -401,6 +412,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true",
+            disabledReason = "target server has no region replication configured")
     void testDurableBlockingWorkflow() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.REGION_DURABLE, ReturnStrategy.BLOCKING_WORKFLOW);
 
@@ -429,6 +442,8 @@ public class TaskClientTests {
     }
 
     @Test
+    @EnabledIfEnvironmentVariable(named = REGION_DURABLE_ENABLED, matches = "true",
+            disabledReason = "target server has no region replication configured")
     void testDurableBlockingTaskInput() throws Exception {
         String workflowId = startComplexWorkflow(Consistency.REGION_DURABLE, ReturnStrategy.BLOCKING_TASK_INPUT);
 

--- a/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
+++ b/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
@@ -118,7 +118,8 @@ public class TestUtil {
             // Check if workflow failed or terminated
             if (workflowDetails.getStatus() == Workflow.WorkflowStatus.FAILED ||
                     workflowDetails.getStatus() == Workflow.WorkflowStatus.TERMINATED) {
-                throw new RuntimeException(describeFailure(workflowDetails));
+                throw new RuntimeException("Workflow ended in unexpected state: " + workflowDetails.getStatus()
+                        + ", reason: " + workflowDetails.getReasonForIncompletion());
             }
 
             Thread.sleep(pollIntervalMs);
@@ -127,22 +128,18 @@ public class TestUtil {
         // Timeout
         Workflow finalState = workflowClient.getWorkflow(workflowId, true);
         throw new TimeoutException(
-                String.format("Workflow %s did not reach status %s within %dms. Current status: %s, tasks: %s",
-                        workflowId, expectedStatus, maxWaitTimeMs, finalState.getStatus(), taskSummary(finalState)));
+                String.format("Workflow %s did not reach status %s within %dms. Current status: %s",
+                        workflowId, expectedStatus, maxWaitTimeMs, finalState.getStatus()));
     }
 
-    /**
-     * Signalling a workflow immediately after start is a race — the task being signalled may not
-     * exist yet. Waits until the workflow is RUNNING with at least one non-terminal task.
-     */
+    /** Waits until the workflow is RUNNING with a non-terminal task, i.e. safe to signal. */
     public static void waitUntilSignalable(OrkesWorkflowClient workflowClient,
                                            String workflowId,
                                            long maxWaitTimeMs,
                                            long pollIntervalMs) {
         await().atMost(Duration.ofMillis(maxWaitTimeMs))
                 .pollInterval(Duration.ofMillis(pollIntervalMs))
-                .failFast("workflow reached a terminal state before it could be signalled",
-                        () -> isTerminalFailure(workflowClient.getWorkflow(workflowId, true)))
+                .failFast(() -> isTerminalFailure(workflowClient.getWorkflow(workflowId, true)))
                 .until(() -> {
                     Workflow workflow = workflowClient.getWorkflow(workflowId, true);
                     return workflow.getStatus() == Workflow.WorkflowStatus.RUNNING
@@ -151,11 +148,7 @@ public class TestUtil {
                 });
     }
 
-    /**
-     * Retries {@code call} until it returns without throwing. For endpoints that are eventually
-     * consistent or intermittently slow, where a single attempt after a fixed sleep turns ordinary
-     * latency into a test failure.
-     */
+    /** Retries {@code call} until it returns without throwing. */
     public static <T> T retryUntil(Callable<T> call, long maxWaitTimeMs, long pollIntervalMs) {
         return await().atMost(Duration.ofMillis(maxWaitTimeMs))
                 .pollInterval(Duration.ofMillis(pollIntervalMs))
@@ -166,25 +159,5 @@ public class TestUtil {
     private static boolean isTerminalFailure(Workflow workflow) {
         return workflow.getStatus() == Workflow.WorkflowStatus.FAILED
                 || workflow.getStatus() == Workflow.WorkflowStatus.TERMINATED;
-    }
-
-    /** Includes the reason and task states — without these a failure is undiagnosable from CI logs. */
-    private static String describeFailure(Workflow workflow) {
-        return String.format("Workflow %s ended in unexpected state: %s. Reason: %s. Tasks: %s",
-                workflow.getWorkflowId(), workflow.getStatus(),
-                workflow.getReasonForIncompletion() == null ? "(none given)" : workflow.getReasonForIncompletion(),
-                taskSummary(workflow));
-    }
-
-    private static String taskSummary(Workflow workflow) {
-        if (workflow.getTasks() == null) {
-            return "[]";
-        }
-        StringBuilder sb = new StringBuilder("[");
-        workflow.getTasks().forEach(t -> sb.append(t.getReferenceTaskName()).append(':')
-                .append(t.getStatus())
-                .append(t.getReasonForIncompletion() == null ? "" : "(" + t.getReasonForIncompletion() + ")")
-                .append(' '));
-        return sb.append(']').toString();
     }
 }

--- a/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
+++ b/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
@@ -114,7 +114,7 @@ public class TestUtil {
             // Check if workflow failed or terminated
             if (workflowDetails.getStatus() == Workflow.WorkflowStatus.FAILED ||
                     workflowDetails.getStatus() == Workflow.WorkflowStatus.TERMINATED) {
-                throw new RuntimeException("Workflow ended in unexpected state: " + workflowDetails.getStatus());
+                throw new RuntimeException(describeFailure(workflowDetails));
             }
 
             Thread.sleep(pollIntervalMs);
@@ -123,7 +123,81 @@ public class TestUtil {
         // Timeout
         Workflow finalState = workflowClient.getWorkflow(workflowId, true);
         throw new TimeoutException(
-                String.format("Workflow %s did not reach status %s within %dms. Current status: %s",
-                        workflowId, expectedStatus, maxWaitTimeMs, finalState.getStatus()));
+                String.format("Workflow %s did not reach status %s within %dms. Current status: %s, tasks: %s",
+                        workflowId, expectedStatus, maxWaitTimeMs, finalState.getStatus(), taskSummary(finalState)));
+    }
+
+    /**
+     * Signalling a workflow immediately after start is a race — the task being signalled may not
+     * exist yet. Waits until the workflow is RUNNING with at least one non-terminal task.
+     */
+    public static void waitUntilSignalable(OrkesWorkflowClient workflowClient,
+                                           String workflowId,
+                                           long maxWaitTimeMs,
+                                           long pollIntervalMs) throws Exception {
+        long endTime = System.currentTimeMillis() + maxWaitTimeMs;
+
+        while (System.currentTimeMillis() < endTime) {
+            Workflow workflow = workflowClient.getWorkflow(workflowId, true);
+
+            if (workflow.getStatus() == Workflow.WorkflowStatus.FAILED
+                    || workflow.getStatus() == Workflow.WorkflowStatus.TERMINATED) {
+                throw new RuntimeException(describeFailure(workflow));
+            }
+            boolean hasPendingTask = workflow.getTasks() != null
+                    && workflow.getTasks().stream().anyMatch(t -> !t.getStatus().isTerminal());
+            if (workflow.getStatus() == Workflow.WorkflowStatus.RUNNING && hasPendingTask) {
+                return;
+            }
+            Thread.sleep(pollIntervalMs);
+        }
+
+        Workflow finalState = workflowClient.getWorkflow(workflowId, true);
+        throw new TimeoutException(String.format(
+                "Workflow %s was not signalable within %dms. Status: %s, tasks: %s",
+                workflowId, maxWaitTimeMs, finalState.getStatus(), taskSummary(finalState)));
+    }
+
+    /** Includes the reason and task states — without these a failure is undiagnosable from CI logs. */
+    private static String describeFailure(Workflow workflow) {
+        return String.format("Workflow %s ended in unexpected state: %s. Reason: %s. Tasks: %s",
+                workflow.getWorkflowId(), workflow.getStatus(),
+                workflow.getReasonForIncompletion() == null ? "(none given)" : workflow.getReasonForIncompletion(),
+                taskSummary(workflow));
+    }
+
+    private static String taskSummary(Workflow workflow) {
+        if (workflow.getTasks() == null) {
+            return "[]";
+        }
+        StringBuilder sb = new StringBuilder("[");
+        workflow.getTasks().forEach(t -> sb.append(t.getReferenceTaskName()).append(':')
+                .append(t.getStatus())
+                .append(t.getReasonForIncompletion() == null ? "" : "(" + t.getReasonForIncompletion() + ")")
+                .append(' '));
+        return sb.append(']').toString();
+    }
+
+    /**
+     * Retries {@code call} until it returns without throwing. Intended for endpoints that are
+     * eventually consistent or intermittently slow, where a single attempt after a fixed sleep
+     * turns ordinary latency into a test failure.
+     */
+    public static <T> T retryUntil(java.util.concurrent.Callable<T> call,
+                                   long maxWaitTimeMs,
+                                   long pollIntervalMs) throws Exception {
+        long endTime = System.currentTimeMillis() + maxWaitTimeMs;
+        Exception last = null;
+
+        while (System.currentTimeMillis() < endTime) {
+            try {
+                return call.call();
+            } catch (Exception e) {
+                last = e;
+                Thread.sleep(pollIntervalMs);
+            }
+        }
+        throw new TimeoutException("Call did not succeed within " + maxWaitTimeMs + "ms"
+                + (last == null ? "" : ", last error: " + last));
     }
 }

--- a/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
+++ b/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
@@ -15,6 +15,8 @@ package io.orkes.conductor.client.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
@@ -24,6 +26,8 @@ import com.netflix.conductor.common.run.Workflow;
 import io.orkes.conductor.client.http.OrkesWorkflowClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.awaitility.Awaitility.await;
 
 public class TestUtil {
     private static int RETRY_ATTEMPT_LIMIT = 4;
@@ -134,28 +138,34 @@ public class TestUtil {
     public static void waitUntilSignalable(OrkesWorkflowClient workflowClient,
                                            String workflowId,
                                            long maxWaitTimeMs,
-                                           long pollIntervalMs) throws Exception {
-        long endTime = System.currentTimeMillis() + maxWaitTimeMs;
+                                           long pollIntervalMs) {
+        await().atMost(Duration.ofMillis(maxWaitTimeMs))
+                .pollInterval(Duration.ofMillis(pollIntervalMs))
+                .failFast("workflow reached a terminal state before it could be signalled",
+                        () -> isTerminalFailure(workflowClient.getWorkflow(workflowId, true)))
+                .until(() -> {
+                    Workflow workflow = workflowClient.getWorkflow(workflowId, true);
+                    return workflow.getStatus() == Workflow.WorkflowStatus.RUNNING
+                            && workflow.getTasks() != null
+                            && workflow.getTasks().stream().anyMatch(t -> !t.getStatus().isTerminal());
+                });
+    }
 
-        while (System.currentTimeMillis() < endTime) {
-            Workflow workflow = workflowClient.getWorkflow(workflowId, true);
+    /**
+     * Retries {@code call} until it returns without throwing. For endpoints that are eventually
+     * consistent or intermittently slow, where a single attempt after a fixed sleep turns ordinary
+     * latency into a test failure.
+     */
+    public static <T> T retryUntil(Callable<T> call, long maxWaitTimeMs, long pollIntervalMs) {
+        return await().atMost(Duration.ofMillis(maxWaitTimeMs))
+                .pollInterval(Duration.ofMillis(pollIntervalMs))
+                .ignoreExceptions()
+                .until(call, result -> true);
+    }
 
-            if (workflow.getStatus() == Workflow.WorkflowStatus.FAILED
-                    || workflow.getStatus() == Workflow.WorkflowStatus.TERMINATED) {
-                throw new RuntimeException(describeFailure(workflow));
-            }
-            boolean hasPendingTask = workflow.getTasks() != null
-                    && workflow.getTasks().stream().anyMatch(t -> !t.getStatus().isTerminal());
-            if (workflow.getStatus() == Workflow.WorkflowStatus.RUNNING && hasPendingTask) {
-                return;
-            }
-            Thread.sleep(pollIntervalMs);
-        }
-
-        Workflow finalState = workflowClient.getWorkflow(workflowId, true);
-        throw new TimeoutException(String.format(
-                "Workflow %s was not signalable within %dms. Status: %s, tasks: %s",
-                workflowId, maxWaitTimeMs, finalState.getStatus(), taskSummary(finalState)));
+    private static boolean isTerminalFailure(Workflow workflow) {
+        return workflow.getStatus() == Workflow.WorkflowStatus.FAILED
+                || workflow.getStatus() == Workflow.WorkflowStatus.TERMINATED;
     }
 
     /** Includes the reason and task states — without these a failure is undiagnosable from CI logs. */
@@ -176,28 +186,5 @@ public class TestUtil {
                 .append(t.getReasonForIncompletion() == null ? "" : "(" + t.getReasonForIncompletion() + ")")
                 .append(' '));
         return sb.append(']').toString();
-    }
-
-    /**
-     * Retries {@code call} until it returns without throwing. Intended for endpoints that are
-     * eventually consistent or intermittently slow, where a single attempt after a fixed sleep
-     * turns ordinary latency into a test failure.
-     */
-    public static <T> T retryUntil(java.util.concurrent.Callable<T> call,
-                                   long maxWaitTimeMs,
-                                   long pollIntervalMs) throws Exception {
-        long endTime = System.currentTimeMillis() + maxWaitTimeMs;
-        Exception last = null;
-
-        while (System.currentTimeMillis() < endTime) {
-            try {
-                return call.call();
-            } catch (Exception e) {
-                last = e;
-                Thread.sleep(pollIntervalMs);
-            }
-        }
-        throw new TimeoutException("Call did not succeed within " + maxWaitTimeMs + "ms"
-                + (last == null ? "" : ", last error: " + last));
     }
 }


### PR DESCRIPTION
Gates the three `REGION_DURABLE` tests behind `CONDUCTOR_REGION_DURABLE_ENABLED` — sdkdev has no replication, and since orkes-conductor 5.5.0 that fails closed where 5.3.0 silently ignored the flag, so they were passing under false pretences.

Also de-flakes the suite: three `signalAsync` tests replaced `Thread.sleep(20)` ("wait for initial execution") with a real wait for a signalable task, `testSearchTasks` retries instead of one shot after a fixed 5s sleep, and `waitForWorkflowStatus` now includes `reasonForIncompletion`.

Declares awaitility properly — `versions.gradle` pinned it but `tests/build.gradle` never depended on it, so `ApiClientTest` was importing testcontainers' shaded copy.

| Check | Result |
|---|---|
| Gating | [32109693272](https://github.com/conductor-oss/java-sdk/actions/runs/32109693272) — 3 SKIPPED, other 103 run, zero REGION_DURABLE errors |
| Stability, 10× sequential | [32113357249](https://github.com/conductor-oss/java-sdk/actions/runs/32113357249) — **10/10 green**, 58 min |
| Head `f4130c53` | [32117303552](https://github.com/conductor-oss/java-sdk/actions/runs/32117303552) — green |

Before this PR the same suite failed 2 tests in a single run.