### PR TITLE
Upgrade to Jackson 3, built against conductor-common 4.0.0-alpha.1

### DIFF
--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example108PlanExecuteRefs.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example108PlanExecuteRefs.java
@@ -33,7 +33,7 @@ import com.netflix.conductor.common.run.Workflow;
 import io.orkes.conductor.client.ApiClient;
 import io.orkes.conductor.client.OrkesClients;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 
 /**

--- a/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example57PlanDryRun.java
+++ b/agent-examples/src/main/java/org/conductoross/conductor/ai/examples/Example57PlanDryRun.java
@@ -22,7 +22,7 @@ import org.conductoross.conductor.ai.internal.AgentConfigSerializer;
 import org.conductoross.conductor.ai.internal.ToolRegistry;
 import org.conductoross.conductor.ai.model.AgentResult;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Example 57 — Plan Dry Run

--- a/build.gradle
+++ b/build.gradle
@@ -59,12 +59,13 @@ subprojects {
         implementation "com.google.guava:guava:${versions.guava}"
         // #################################
 
-        implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
-        implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-        implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-        implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
-        implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${versions.jackson}"
-        implementation "com.fasterxml.jackson.module:jackson-module-afterburner:${versions.jackson}"
+        // Jackson 3: databind/core/modules live under tools.jackson; annotations remain on the
+        // com.fasterxml.jackson 2.x line. java.time (jsr310) and jdk8 datatypes plus the
+        // afterburner optimisations are part of core in Jackson 3, so those modules are gone.
+        implementation "tools.jackson.core:jackson-databind:${versions.jackson}"
+        implementation "tools.jackson.core:jackson-core:${versions.jackson}"
+        implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jacksonAnnotations}"
+        implementation "tools.jackson.module:jackson-module-kotlin:${versions.jackson}"
         implementation "org.openjdk.nashorn:nashorn-core:15.6"
 
         implementation "org.slf4j:slf4j-api:${versions.slf4j}"

--- a/conductor-client-ai/build.gradle
+++ b/conductor-client-ai/build.gradle
@@ -17,11 +17,10 @@ dependencies {
     // so downstream modules and user code must see conductor-client transitively.
     api project(":conductor-client")
 
-    api "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
-    api "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-    api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
-    // not injected by the root subprojects block — must stay explicit
-    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
+    // Jackson 3: jsr310/jdk8 datatypes are part of core, so only databind and the
+    // 2.x-line annotations remain on the public surface.
+    api "tools.jackson.core:jackson-databind:${versions.jackson}"
+    api "com.fasterxml.jackson.core:jackson-annotations:${versions.jacksonAnnotations}"
 
     // compileOnly so the SDK doesn't force LLM frameworks onto users: the framework
     // bridge classes only link at runtime when the user passes a native object in —

--- a/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/execution/JupyterCodeExecutor.java
+++ b/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/execution/JupyterCodeExecutor.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import org.conductoross.conductor.ai.internal.JsonMapper;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Execute code against a Jupyter Kernel Gateway.

--- a/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/execution/ServerlessCodeExecutor.java
+++ b/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/execution/ServerlessCodeExecutor.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import org.conductoross.conductor.ai.internal.JsonMapper;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Execute code via a remote serverless execution service.

--- a/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/internal/AgentConfigSerializer.java
+++ b/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/internal/AgentConfigSerializer.java
@@ -12,7 +12,6 @@
  */
 package org.conductoross.conductor.ai.internal;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -35,9 +34,9 @@ import org.conductoross.conductor.ai.plans.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
 /**
  * Serializes an {@link Agent} tree to the camelCase JSON dict for POST /agent/start.
@@ -727,18 +726,18 @@ public class AgentConfigSerializer {
     }
 
     /**
-     * Jackson {@link JsonSerializer} that delegates to {@link AgentConfigSerializer#serialize(Agent)}.
+     * Jackson {@link ValueSerializer} that delegates to {@link AgentConfigSerializer#serialize(Agent)}.
      * Applied via {@code @JsonSerialize(using = AgentConfigSerializer.AsJson.class)} on
      * {@code Agent}-typed fields so Jackson writes the correct wire format (camelCase
      * map matching the server's AgentConfig DTO) without requiring the caller to
      * pre-serialize to a Map.
      */
-    public static final class AsJson extends JsonSerializer<Agent> {
+    public static final class AsJson extends ValueSerializer<Agent> {
         private static final AgentConfigSerializer INSTANCE = new AgentConfigSerializer();
 
         @Override
-        public void serialize(Agent agent, JsonGenerator gen, SerializerProvider provider) throws IOException {
-            provider.defaultSerializeValue(INSTANCE.serialize(agent), gen);
+        public void serialize(Agent agent, JsonGenerator gen, SerializationContext context) {
+            context.writeValue(gen, INSTANCE.serialize(agent));
         }
     }
 }

--- a/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/internal/JsonMapper.java
+++ b/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/internal/JsonMapper.java
@@ -13,26 +13,29 @@
 package org.conductoross.conductor.ai.internal;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
 
 /**
  * Singleton ObjectMapper factory with consistent configuration.
+ *
+ * <p>Unlike the client's ObjectMapperProvider (which keeps the numeric timestamp wire format for
+ * server compatibility), this mapper intentionally writes dates as ISO-8601 strings. The jdk8 and
+ * java.time datatypes are part of Jackson 3 core, so no modules are registered. The builder is
+ * referenced by its fully qualified name because this class shares the JsonMapper simple name.
  */
 public class JsonMapper {
-    private static final ObjectMapper INSTANCE;
-
-    static {
-        INSTANCE = new ObjectMapper();
-        INSTANCE.registerModule(new JavaTimeModule());
-        INSTANCE.registerModule(new Jdk8Module());
-        INSTANCE.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        INSTANCE.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        INSTANCE.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
+    private static final ObjectMapper INSTANCE =
+            tools.jackson.databind.json.JsonMapper.builder()
+                    .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                    .changeDefaultPropertyInclusion(
+                            value ->
+                                    JsonInclude.Value.construct(
+                                            JsonInclude.Include.NON_NULL,
+                                            JsonInclude.Include.USE_DEFAULTS))
+                    .build();
 
     private JsonMapper() {}
 

--- a/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/internal/ToolRegistry.java
+++ b/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/internal/ToolRegistry.java
@@ -322,9 +322,9 @@ public class ToolRegistry {
         // even when the method signature declares List<Double>.
         if (List.class.isAssignableFrom(targetType)) {
             try {
-                com.fasterxml.jackson.databind.type.TypeFactory tf =
+                tools.jackson.databind.type.TypeFactory tf =
                         JsonMapper.get().getTypeFactory();
-                com.fasterxml.jackson.databind.JavaType jt = (genericType != null)
+                tools.jackson.databind.JavaType jt = (genericType != null)
                         ? tf.constructType(genericType)
                         : tf.constructCollectionType(List.class, Object.class);
                 return JsonMapper.get().convertValue(value, jt);
@@ -355,7 +355,7 @@ public class ToolRegistry {
         }
         // Fallback: try Jackson conversion for complex types
         try {
-            com.fasterxml.jackson.databind.JavaType jt = (genericType != null)
+            tools.jackson.databind.JavaType jt = (genericType != null)
                     ? JsonMapper.get().getTypeFactory().constructType(genericType)
                     : JsonMapper.get().getTypeFactory().constructType(targetType);
             return JsonMapper.get().convertValue(value, jt);

--- a/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/model/AgentResult.java
+++ b/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/model/AgentResult.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import org.conductoross.conductor.ai.enums.AgentStatus;
 import org.conductoross.conductor.ai.internal.JsonMapper;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * The result of a completed agent execution.

--- a/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/plans/Plan.java
+++ b/conductor-client-ai/src/main/java/org/conductoross/conductor/ai/plans/Plan.java
@@ -12,15 +12,14 @@
  */
 package org.conductoross.conductor.ai.plans;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
 /**
  * A compiled plan ready for {@code Strategy.PLAN_EXECUTE} execution.
@@ -114,10 +113,10 @@ public final class Plan {
      * in {@code AgentRequest} writes the correct wire format without the caller
      * pre-converting to a {@code Map}.
      */
-    public static final class AsJson extends JsonSerializer<Plan> {
+    public static final class AsJson extends ValueSerializer<Plan> {
         @Override
-        public void serialize(Plan plan, JsonGenerator gen, SerializerProvider provider) throws IOException {
-            provider.defaultSerializeValue(plan.toJson(), gen);
+        public void serialize(Plan plan, JsonGenerator gen, SerializationContext context) {
+            context.writeValue(gen, plan.toJson());
         }
     }
 }

--- a/conductor-client-ai/src/test/java/org/conductoross/conductor/ai/AgentRuntimeRunSettingsWireTest.java
+++ b/conductor-client-ai/src/test/java/org/conductoross/conductor/ai/AgentRuntimeRunSettingsWireTest.java
@@ -21,11 +21,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/conductor-client-ai/src/test/java/org/conductoross/conductor/ai/model/AgentHandleErrorTest.java
+++ b/conductor-client-ai/src/test/java/org/conductoross/conductor/ai/model/AgentHandleErrorTest.java
@@ -23,7 +23,7 @@ import io.orkes.conductor.client.AgentClient;
 import io.orkes.conductor.client.http.OrkesAgentClient;
 import io.orkes.conductor.client.model.agent.AgentStatusResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client-spring-boot4/build.gradle
+++ b/conductor-client-spring-boot4/build.gradle
@@ -20,9 +20,9 @@ repositories {
 
 dependencies {
     api project(":conductor-client")
-    implementation 'org.springframework.boot:spring-boot-starter:4.0.6'
+    implementation 'org.springframework.boot:spring-boot-starter:4.1.1'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:4.0.6'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:4.1.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "org.mockito:mockito-junit-jupiter:${versions.mockito}"

--- a/conductor-client/build.gradle
+++ b/conductor-client/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
     testImplementation 'org.codehaus.groovy:groovy:3.0.25'
     testImplementation 'ch.qos.logback:logback-classic:1.5.32'
-    testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
 }
 
 java {

--- a/conductor-client/src/main/java/com/netflix/conductor/client/http/ConductorClient.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/client/http/ConductorClient.java
@@ -53,10 +53,6 @@ import com.netflix.conductor.client.metrics.MetricsCollector;
 import com.netflix.conductor.client.metrics.PayloadKind;
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import okhttp3.Call;
 import okhttp3.ConnectionPool;
@@ -68,6 +64,10 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.internal.http.HttpMethod;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
 
 public class ConductorClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConductorClient.class);
@@ -403,7 +403,7 @@ public class ConductorClient {
                 ConductorClientException exception = objectMapper.readValue(respBody, ConductorClientException.class);
                 exception.setStatus(response.code());
                 throw exception;
-            } catch (JsonProcessingException jpe) {
+            } catch (JacksonException jpe) {
                 // Ignore
             }
             throw new ConductorClientException(response.message(),

--- a/conductor-client/src/main/java/com/netflix/conductor/client/http/EventClient.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/client/http/EventClient.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang3.Validate;
 import com.netflix.conductor.client.http.ConductorClientRequest.Method;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 
 

--- a/conductor-client/src/main/java/com/netflix/conductor/client/http/MetadataClient.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/client/http/MetadataClient.java
@@ -20,7 +20,7 @@ import com.netflix.conductor.client.http.ConductorClientRequest.Method;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 public class MetadataClient {
 

--- a/conductor-client/src/main/java/com/netflix/conductor/client/http/PayloadStorage.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/client/http/PayloadStorage.java
@@ -28,8 +28,8 @@ import com.netflix.conductor.client.exception.ConductorClientException;
 import com.netflix.conductor.common.run.ExternalStorageLocation;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.type.TypeReference;
 
 /** An implementation of {@link ExternalPayloadStorage} for storing large JSON payload data. */
 @Slf4j

--- a/conductor-client/src/main/java/com/netflix/conductor/client/http/TaskClient.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/client/http/TaskClient.java
@@ -54,9 +54,9 @@ import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Client for conductor task management including polling for task, updating

--- a/conductor-client/src/main/java/com/netflix/conductor/client/http/WorkflowClient.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/client/http/WorkflowClient.java
@@ -65,9 +65,9 @@ import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.common.run.WorkflowTestRequest;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 public class WorkflowClient implements AutoCloseable {

--- a/conductor-client/src/main/java/com/netflix/conductor/common/config/ObjectMapperProvider.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/common/config/ObjectMapperProvider.java
@@ -13,33 +13,49 @@
 package com.netflix.conductor.common.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
-import com.fasterxml.jackson.module.kotlin.KotlinModule;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.module.kotlin.KotlinModule;
 
 public class ObjectMapperProvider {
 
     private static final ObjectMapper objectMapper = _getObjectMapper();
 
+    /**
+     * The signature and configuration of this method are kept aligned with
+     * com.netflix.conductor.common.config.ObjectMapperProvider in org.conductoross:conductor-common
+     * (4.0.0-alpha.1 and later). When both jars are on one classpath only one copy of this class
+     * loads, so the two must stay interchangeable.
+     */
     public ObjectMapper getObjectMapper() {
         return objectMapper;
     }
 
+    /**
+     * Jackson 3 mappers are immutable, so every setting is applied on the builder. The jdk8 and
+     * java.time datatypes and the property-access optimisations that used to need separate modules
+     * (jdk8, jsr310, afterburner) are part of the core now, which is why only the Kotlin module is
+     * registered here.
+     *
+     * <p>WRITE_DATES_AS_TIMESTAMPS is enabled to keep the numeric date encoding that Jackson 2
+     * produced with JavaTimeModule. Jackson 3 defaults to ISO-8601 strings, which would change the
+     * payload format sent to and stored by the server.
+     */
     private static ObjectMapper _getObjectMapper() {
-        final ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
-        objectMapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
-        objectMapper.setDefaultPropertyInclusion(
-                JsonInclude.Value.construct(
-                        JsonInclude.Include.NON_NULL, JsonInclude.Include.ALWAYS));
-        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.registerModule(new AfterburnerModule());
-        objectMapper.registerModule(new KotlinModule.Builder().build());
-        return objectMapper;
+        return JsonMapper.builder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
+                .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .changeDefaultPropertyInclusion(
+                        value ->
+                                JsonInclude.Value.construct(
+                                        JsonInclude.Include.NON_NULL, JsonInclude.Include.ALWAYS))
+                .addModule(new KotlinModule.Builder().build())
+                .build();
     }
 }

--- a/conductor-client/src/main/java/com/netflix/conductor/common/utils/MetadataUtils.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/common/utils/MetadataUtils.java
@@ -19,8 +19,8 @@ import java.util.Objects;
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
+import tools.jackson.databind.ObjectMapper;
 
 public final class MetadataUtils {
 

--- a/conductor-client/src/main/java/com/netflix/conductor/common/utils/SummaryUtil.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/common/utils/SummaryUtil.java
@@ -19,8 +19,8 @@ import org.slf4j.LoggerFactory;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 public class SummaryUtil {
 
@@ -49,7 +49,7 @@ public class SummaryUtil {
         }
         try {
             return objectMapper.writeValueAsString(object);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             logger.error("The provided value ({}) could not be serialized as Json", object.toString(), e);
             throw new RuntimeException(e);
         }

--- a/conductor-client/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
@@ -15,8 +15,8 @@ package com.netflix.conductor.common.utils;
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 public class TaskUtils {
 

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/healthcheck/HealthCheckClient.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/healthcheck/HealthCheckClient.java
@@ -16,8 +16,9 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class HealthCheckClient {
 
@@ -28,8 +29,9 @@ public class HealthCheckClient {
     public HealthCheckClient(String healthCheckURL) {
         this.healthCheckURL = healthCheckURL;
         this.objectMapper =
-                new ObjectMapper()
-                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+                JsonMapper.builder()
+                        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                        .build();
     }
 
     public boolean isServerRunning() {

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/ConductorWorkflow.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/ConductorWorkflow.java
@@ -32,8 +32,8 @@ import com.netflix.conductor.sdk.workflow.def.tasks.TaskRegistry;
 import com.netflix.conductor.sdk.workflow.executor.WorkflowExecutor;
 import com.netflix.conductor.sdk.workflow.utils.InputOutputGetter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * @param <T> Type of the workflow input
@@ -378,7 +378,7 @@ public class ConductorWorkflow<T> {
     public String toString() {
         try {
             return objectMapper.writeValueAsString(toWorkflowDef());
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new RuntimeException(e);
         }
     }

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/WorkflowBuilder.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/WorkflowBuilder.java
@@ -28,7 +28,7 @@ import com.netflix.conductor.sdk.workflow.executor.WorkflowExecutor;
 import com.netflix.conductor.sdk.workflow.utils.InputOutputGetter;
 import com.netflix.conductor.sdk.workflow.utils.MapBuilder;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * @param <T> Input type for the workflow

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Http.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Http.java
@@ -23,7 +23,7 @@ import com.netflix.conductor.common.config.ObjectMapperProvider;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 /** Wait task */
 public class Http extends Task<Http> {

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Task.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Task.java
@@ -23,8 +23,8 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.sdk.workflow.utils.InputOutputGetter;
 import com.netflix.conductor.sdk.workflow.utils.MapBuilder;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import tools.jackson.databind.ObjectMapper;
 
 /** Workflow Task */
 public abstract class Task<T> {

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
@@ -64,8 +64,8 @@ import com.netflix.conductor.sdk.workflow.def.tasks.Terminate;
 import com.netflix.conductor.sdk.workflow.def.tasks.Wait;
 import com.netflix.conductor.sdk.workflow.executor.task.AnnotatedWorkerExecutor;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 public class WorkflowExecutor {
 

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
@@ -12,7 +12,6 @@
  */
 package com.netflix.conductor.sdk.workflow.executor.task;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -32,11 +31,9 @@ import com.netflix.conductor.sdk.workflow.task.InputParam;
 import com.netflix.conductor.sdk.workflow.task.OutputParam;
 import com.netflix.conductor.sdk.workflow.task.WorkflowInstanceIdInputParam;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 public class AnnotatedWorker implements Worker {
@@ -58,7 +55,8 @@ public class AnnotatedWorker implements Worker {
         this.name = name;
         this.workerMethod = workerMethod;
         this.obj = obj;
-        om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        // FAIL_ON_UNKNOWN_PROPERTIES is already disabled by ObjectMapperProvider; Jackson 3
+        // mappers are immutable so it can no longer be re-applied here.
     }
 
     @Override
@@ -190,10 +188,9 @@ public class AnnotatedWorker implements Worker {
     }
 
     private Object convertValue(Object source, Class<?> targetType) {
-        JsonNode tree = om.valueToTree(source);
-        try (JsonParser parser = tree.traverse(om)) {
-            return om.readerFor(targetType).readValue(parser);
-        } catch (IOException e) {
+        try {
+            return om.convertValue(source, targetType);
+        } catch (JacksonException e) {
             throw new RuntimeException("Failed to bind task input to " + targetType.getName(), e);
         }
     }

--- a/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/DynamicForkWorker.java
+++ b/conductor-client/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/DynamicForkWorker.java
@@ -25,7 +25,7 @@ import com.netflix.conductor.sdk.workflow.def.tasks.DynamicFork;
 import com.netflix.conductor.sdk.workflow.def.tasks.DynamicForkInput;
 import com.netflix.conductor.sdk.workflow.task.InputParam;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class DynamicForkWorker implements Worker {
 

--- a/conductor-client/src/main/java/io/orkes/conductor/client/SseClient.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/SseClient.java
@@ -31,11 +31,11 @@ import com.netflix.conductor.common.config.ObjectMapperProvider;
 import io.orkes.conductor.client.exceptions.SSEUnavailableException;
 import io.orkes.conductor.client.http.Pair;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.Call;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Server-Sent Events (SSE) client for streaming agent events

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/ApplicationResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/ApplicationResource.java
@@ -26,7 +26,7 @@ import io.orkes.conductor.client.model.CreateAccessKeyResponse;
 import io.orkes.conductor.client.model.CreateOrUpdateApplicationRequest;
 import io.orkes.conductor.client.model.TagObject;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 class ApplicationResource {
 

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/AuthorizationResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/AuthorizationResource.java
@@ -24,7 +24,7 @@ import com.netflix.conductor.client.http.ConductorClientResponse;
 import io.orkes.conductor.client.model.AuthorizationRequest;
 import io.orkes.conductor.client.model.Subject;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 class AuthorizationResource {
     

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/EnvironmentResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/EnvironmentResource.java
@@ -23,7 +23,7 @@ import com.netflix.conductor.client.http.ConductorClientResponse;
 import io.orkes.conductor.client.model.Tag;
 import io.orkes.conductor.client.model.environment.EnvironmentVariable;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 class EnvironmentResource {
 
@@ -73,7 +73,7 @@ class EnvironmentResource {
                 .path("/environment/{key}")
                 .addPathParam("key", key)
                 .build();
-        ConductorClientResponse<String> resp = client.execute(request, new com.fasterxml.jackson.core.type.TypeReference<>() {});
+        ConductorClientResponse<String> resp = client.execute(request, new tools.jackson.core.type.TypeReference<>() {});
         return resp.getData();
     }
 

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/EventResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/EventResource.java
@@ -25,7 +25,7 @@ import com.netflix.conductor.common.metadata.events.EventHandler;
 import io.orkes.conductor.client.model.OrkesEventHandler;
 import io.orkes.conductor.client.model.Tag;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 class EventResource {
 

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/GroupResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/GroupResource.java
@@ -24,7 +24,7 @@ import io.orkes.conductor.client.model.GrantedAccessResponse;
 import io.orkes.conductor.client.model.Group;
 import io.orkes.conductor.client.model.UpsertGroupRequest;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 class GroupResource {
 

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/IntegrationResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/IntegrationResource.java
@@ -29,7 +29,7 @@ import io.orkes.conductor.client.model.integration.IntegrationApi;
 import io.orkes.conductor.client.model.integration.IntegrationApiUpdate;
 import io.orkes.conductor.client.model.integration.IntegrationUpdate;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 
 class IntegrationResource {

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/MetadataResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/MetadataResource.java
@@ -24,7 +24,7 @@ import com.netflix.conductor.client.http.ConductorClientResponse;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 public class MetadataResource {
 

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/OrkesAgentClient.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/OrkesAgentClient.java
@@ -33,7 +33,7 @@ import io.orkes.conductor.client.model.agent.CompileResponse;
 import io.orkes.conductor.client.model.agent.RespondBody;
 import io.orkes.conductor.client.model.agent.StartResponse;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Orkes implementation of {@link AgentClient} for the agent control-plane

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/OrkesPromptClient.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/OrkesPromptClient.java
@@ -26,7 +26,7 @@ import com.netflix.conductor.client.http.ConductorClientResponse;
 import io.orkes.conductor.client.PromptClient;
 import io.orkes.conductor.client.model.TagObject;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 public class OrkesPromptClient implements PromptClient {
 

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/OrkesServiceRegistryClient.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/OrkesServiceRegistryClient.java
@@ -29,8 +29,8 @@ import com.netflix.conductor.common.model.ServiceRegistry;
 
 import io.orkes.conductor.client.ServiceRegistryClient;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Client for the Service Registry API

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/SchedulerBulkResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/SchedulerBulkResource.java
@@ -20,7 +20,7 @@ import com.netflix.conductor.client.http.ConductorClientRequest.Method;
 import com.netflix.conductor.client.http.ConductorClientResponse;
 import com.netflix.conductor.common.model.BulkResponse;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 
 class SchedulerBulkResource {

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/SchedulerResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/SchedulerResource.java
@@ -26,7 +26,7 @@ import io.orkes.conductor.client.model.SearchResultWorkflowScheduleExecution;
 import io.orkes.conductor.client.model.TagObject;
 import io.orkes.conductor.client.model.WorkflowSchedule;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 
 public class SchedulerResource {

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/SchemaResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/SchemaResource.java
@@ -20,7 +20,7 @@ import com.netflix.conductor.client.http.ConductorClientRequest.Method;
 import com.netflix.conductor.client.http.ConductorClientResponse;
 import com.netflix.conductor.common.metadata.SchemaDef;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 class SchemaResource {
 

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/SecretResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/SecretResource.java
@@ -21,7 +21,7 @@ import com.netflix.conductor.client.http.ConductorClientResponse;
 
 import io.orkes.conductor.client.model.TagObject;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 public class SecretResource {
     private final ConductorClient client;

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/TagsResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/TagsResource.java
@@ -22,7 +22,7 @@ import com.netflix.conductor.client.http.ConductorClientResponse;
 import io.orkes.conductor.client.model.TagObject;
 import io.orkes.conductor.client.model.TagString;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 
 public class TagsResource {

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/TokenRefreshInterceptor.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/TokenRefreshInterceptor.java
@@ -18,11 +18,11 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Application interceptor that handles token expiry transparently.

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/TokenResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/TokenResource.java
@@ -21,7 +21,7 @@ import io.orkes.conductor.client.model.ConductorUser;
 import io.orkes.conductor.client.model.GenerateTokenRequest;
 import io.orkes.conductor.client.model.TokenResponse;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 
 public class TokenResource {

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/UserResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/UserResource.java
@@ -23,7 +23,7 @@ import io.orkes.conductor.client.model.ConductorUser;
 import io.orkes.conductor.client.model.GrantedAccessResponse;
 import io.orkes.conductor.client.model.UpsertUserRequest;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 
 class UserResource {

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/WorkflowBulkResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/WorkflowBulkResource.java
@@ -20,7 +20,7 @@ import com.netflix.conductor.client.http.ConductorClientRequest.Method;
 import com.netflix.conductor.client.http.ConductorClientResponse;
 import com.netflix.conductor.common.model.BulkResponse;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 
 class WorkflowBulkResource {

--- a/conductor-client/src/main/java/io/orkes/conductor/client/http/WorkflowResource.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/http/WorkflowResource.java
@@ -27,7 +27,7 @@ import io.orkes.conductor.client.enums.Consistency;
 import io.orkes.conductor.client.enums.ReturnStrategy;
 import io.orkes.conductor.client.model.*;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import tools.jackson.core.type.TypeReference;
 
 
 class WorkflowResource {

--- a/conductor-client/src/main/java/io/orkes/conductor/client/model/event/QueueConfiguration.java
+++ b/conductor-client/src/main/java/io/orkes/conductor/client/model/event/QueueConfiguration.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public abstract class QueueConfiguration {
 

--- a/conductor-client/src/main/java/org/conductoross/conductor/client/FileClient.java
+++ b/conductor-client/src/main/java/org/conductoross/conductor/client/FileClient.java
@@ -45,8 +45,8 @@ import com.netflix.conductor.client.http.ConductorClientRequest.Method;
 
 import io.orkes.conductor.client.http.ApiException;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import okhttp3.OkHttpClient;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Workflow-scoped client for Conductor file storage.

--- a/conductor-client/src/test/groovy/com/netflix/conductor/client/http/ClientSpecification.groovy
+++ b/conductor-client/src/test/groovy/com/netflix/conductor/client/http/ClientSpecification.groovy
@@ -12,7 +12,7 @@
  */
 package com.netflix.conductor.client.http
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import com.netflix.conductor.common.config.ObjectMapperProvider
 import spock.lang.Specification
 

--- a/conductor-client/src/test/groovy/com/netflix/conductor/client/http/MetadataClientSpec.groovy
+++ b/conductor-client/src/test/groovy/com/netflix/conductor/client/http/MetadataClientSpec.groovy
@@ -12,7 +12,7 @@
  */
 package com.netflix.conductor.client.http
 
-import com.fasterxml.jackson.core.type.TypeReference
+import tools.jackson.core.type.TypeReference
 import com.netflix.conductor.client.exception.ConductorClientException
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef
 import spock.lang.Subject

--- a/conductor-client/src/test/java/com/netflix/conductor/client/testing/AbstractWorkflowTests.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/client/testing/AbstractWorkflowTests.java
@@ -37,8 +37,8 @@ import com.netflix.conductor.common.run.WorkflowTestRequest;
 import io.orkes.conductor.client.ServiceRegistryClient;
 import io.orkes.conductor.client.http.OrkesServiceRegistryClient;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/conductor-client/src/test/java/com/netflix/conductor/client/worker/TestWorkflowTask.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/client/worker/TestWorkflowTask.java
@@ -23,7 +23,7 @@ import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/TestSerDerAuditable.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/TestSerDerAuditable.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/TestSerDerSchemaDef.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/TestSerDerSchemaDef.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/events/TestSerDerEventExecution.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/events/TestSerDerEventExecution.java
@@ -21,7 +21,7 @@ import com.netflix.conductor.common.metadata.events.EventExecution.Status;
 import com.netflix.conductor.common.metadata.events.EventHandler.Action;
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/events/TestSerDerEventHandler.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/events/TestSerDerEventHandler.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TaskDefSerDerTest.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TaskDefSerDerTest.java
@@ -21,7 +21,7 @@ import com.netflix.conductor.common.metadata.tasks.TaskDef.RetryLogic;
 import com.netflix.conductor.common.metadata.tasks.TaskDef.TimeoutPolicy;
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TestSerDerPollData.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TestSerDerPollData.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TestSerDerTask.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TestSerDerTask.java
@@ -19,8 +19,8 @@ import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -28,16 +28,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 //todo add fields in the sdk pojo TaskDef - it will pass this test
 public class TestSerDerTask {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+            .build();
 
     @Test
     public void testSerializationDeserialization() throws Exception {
         // 1. Unmarshal SERVER_JSON to SDK POJO
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("Task");
-        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        objectMapper.registerModule(new Jdk8Module());
         Task task = objectMapper.readValue(SERVER_JSON, Task.class);
 
         // 2. Assert that fields are correctly populated

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TestSerDerTaskExecLog.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TestSerDerTaskExecLog.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TestSerDerTaskResult.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/tasks/TestSerDerTaskResult.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import com.netflix.conductor.common.metadata.tasks.TaskResult.Status;
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerDynamicForkJoinTask.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerDynamicForkJoinTask.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerDynamicForkJoinTaskList.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerDynamicForkJoinTaskList.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerRateLimitConfig.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerRateLimitConfig.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerRerunWorkflowRequest.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerRerunWorkflowRequest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerStartWorkflowRequest.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerStartWorkflowRequest.java
@@ -18,14 +18,21 @@ import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 //todo add fields in TaskDef class of sdk - this test will pass
 public class TestSerDerStartWorkflowRequest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+            .build();
 
     @Test
     public void testSerializeDeserialize() throws Exception {
@@ -33,8 +40,6 @@ public class TestSerDerStartWorkflowRequest {
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("StartWorkflowRequest");
 
         // 2. Unmarshal SERVER_JSON to SDK POJO
-        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         StartWorkflowRequest startWorkflowRequest = objectMapper.readValue(SERVER_JSON, StartWorkflowRequest.class);
 
         // 3. Assert that the fields are all correctly populated

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerStateChangeEvent.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerStateChangeEvent.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerSubWorkflowParams.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerSubWorkflowParams.java
@@ -21,22 +21,27 @@ import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestSerDerSubWorkflowParams {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                            .withVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE))
+            .build();
 
     @Test
     public void testSerializationDeserialization() throws IOException {
         // 1. Unmarshal SERVER_JSON to SDK POJO
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("SubWorkflowParams");
-        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        objectMapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
         SubWorkflowParams subWorkflowParams = objectMapper.readValue(SERVER_JSON, SubWorkflowParams.class);
 
         // 2. Assert that the fields are all correctly populated

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerUpgradeWorkflowRequest.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerUpgradeWorkflowRequest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerWorkflowDef.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerWorkflowDef.java
@@ -22,7 +22,8 @@ import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -32,14 +33,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 //todo add missing fields in Taskdef - should pass this test
 class TestSerDerWorkflowDef {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+            .build();
 
     @Test
     void testSerializationDeserialization() throws Exception {
         // 1. Unmarshal SERVER_JSON to SDK POJO
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("WorkflowDef");
-        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         WorkflowDef workflowDef = objectMapper.readValue(SERVER_JSON, WorkflowDef.class);
 
         // 2. Assert that the fields are all correctly populated

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerWorkflowDefSummary.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerWorkflowDefSummary.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerWorkflowTask.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSerDerWorkflowTask.java
@@ -18,7 +18,8 @@ import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,14 +28,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 // todo  missing fields in the dependent pojos - fixing that should pass this test
 public class TestSerDerWorkflowTask {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+            .build();
 
     @Test
     public void testSerializeDeserialize() throws Exception {
         // 1. Unmarshal SERVER_JSON to SDK POJO
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("WorkflowTask");
-        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         WorkflowTask workflowTask = objectMapper.readValue(SERVER_JSON, WorkflowTask.class);
 
         // 2. Assert that the fields are all correctly populated

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSkipTaskRequestSerDer.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/TestSkipTaskRequestSerDer.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/WorkflowDefDeserializationTest.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/metadata/workflow/WorkflowDefDeserializationTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 
 class WorkflowDefDeserializationTest {

--- a/conductor-client/src/test/java/com/netflix/conductor/common/model/TestSerDerBulkResponse.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/model/TestSerDerBulkResponse.java
@@ -17,8 +17,9 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -29,8 +30,9 @@ class TestSerDerBulkResponse {
 
     @BeforeEach
     void setUp() {
-        objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper = JsonMapper.builder()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .build();
     }
 
     @Test

--- a/conductor-client/src/test/java/com/netflix/conductor/common/run/TaskSummarySerDeTest.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/run/TaskSummarySerDeTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerExternalStorageLocation.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerExternalStorageLocation.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerSearchResult.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerSearchResult.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerWorkflow.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerWorkflow.java
@@ -23,10 +23,10 @@ import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -35,17 +35,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 // todo fix missing field in dependent sdk pojos should pass the test
 public class TestSerDerWorkflow {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+            .build();
 
 
     @Test
     public void testSerializationAndDeserialization() throws Exception {
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("Workflow");
         // 1. Unmarshal SERVER_JSON to SDK POJO
-        objectMapper.registerModule(new Jdk8Module());
-        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-
         // 1. Unmarshal SERVER_JSON to SDK POJO
         Workflow workflow = objectMapper.readValue(SERVER_JSON, Workflow.class);
 

--- a/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerWorkflowSummary.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerWorkflowSummary.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
 import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -77,7 +77,7 @@ class TestSerDerWorkflowSummary {
         JsonNode reserializedJson = objectMapper.readTree(serializedJson);
 
         // Verify each field from the original exists in the reserialized version with same value
-        originalJson.fieldNames().forEachRemaining(fieldName -> {
+        originalJson.propertyNames().forEach(fieldName -> {
             assertTrue(reserializedJson.has(fieldName), "Field " + fieldName + " should exist in reserialized JSON");
             assertEquals(
                     originalJson.get(fieldName),

--- a/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerWorkflowTestRequest.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/run/TestSerDerWorkflowTestRequest.java
@@ -22,7 +22,8 @@ import com.netflix.conductor.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,15 +32,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 // todo fix missing fields in dependent sdk pojos - should pass this test
 public class TestSerDerWorkflowTestRequest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+            .build();
 
     @Test
     public void testSerializationDeserialization() throws Exception {
         // 1. Unmarshal SERVER_JSON to SDK POJO
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("WorkflowTestRequest");
         // Configure ObjectMapper to ignore deprecated fields
-        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         WorkflowTestRequest workflowTestRequest = objectMapper.readValue(SERVER_JSON, WorkflowTestRequest.class);
 
         // 2. Assert that the fields are all correctly populated

--- a/conductor-client/src/test/java/com/netflix/conductor/common/run/tasks/TypedTaskTest.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/common/run/tasks/TypedTaskTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.run.Workflow;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/com/netflix/conductor/util/JsonTemplateSerDeserResolverUtil.java
+++ b/conductor-client/src/test/java/com/netflix/conductor/util/JsonTemplateSerDeserResolverUtil.java
@@ -18,10 +18,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Utility class for resolving JSON templates from a predefined resource file.
@@ -112,7 +112,7 @@ public class JsonTemplateSerDeserResolverUtil {
         }
 
         // Create a deep copy of the content node
-        ObjectNode resultNode = contentNode.deepCopy();
+        ObjectNode resultNode = (ObjectNode) contentNode.deepCopy();
 
         // Process inheritance if present
         JsonNode inheritsNode = template.get("inherits");
@@ -139,7 +139,7 @@ public class JsonTemplateSerDeserResolverUtil {
      */
     private static void mergeNodes(ObjectNode target, JsonNode source) {
         if (source.isObject()) {
-            Iterator<String> fieldNames = source.fieldNames();
+            Iterator<String> fieldNames = source.propertyNames().iterator();
             while (fieldNames.hasNext()) {
                 String fieldName = fieldNames.next();
                 JsonNode sourceValue = source.get(fieldName);
@@ -173,7 +173,7 @@ public class JsonTemplateSerDeserResolverUtil {
      * Resolves references in an object node.
      */
     private static void resolveObjectReferences(ObjectNode objectNode, Set<String> processedDependencies) throws IOException {
-        Iterator<String> fieldNames = objectNode.fieldNames();
+        Iterator<String> fieldNames = objectNode.propertyNames().iterator();
         Set<String> fieldsToProcess = new HashSet<>();
 
         // Collect field names to avoid ConcurrentModificationException
@@ -203,7 +203,7 @@ public class JsonTemplateSerDeserResolverUtil {
                 JsonNode resolvedReference = resolveTemplateWithInheritance(referenceName, new HashSet<>());
 
                 // Only apply if the resolved reference is a simple value (string, number, etc.)
-                if (!resolvedReference.isContainerNode()) {
+                if (!resolvedReference.isContainer()) {
                     String resolvedKey = resolvedReference.asText();
 
                     // Remove the original reference key and add the resolved key with the same value

--- a/conductor-client/src/test/java/io/orkes/conductor/client/http/TokenRefreshTest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/http/TokenRefreshTest.java
@@ -28,12 +28,12 @@ import com.netflix.conductor.client.http.ConductorClientResponse;
 
 import io.orkes.conductor.client.ApiClient;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.cache.Cache;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import tools.jackson.core.type.TypeReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerAccessKeyResponse.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerAccessKeyResponse.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerAuthorizationRequest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerAuthorizationRequest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerConductorApplication.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerConductorApplication.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerConductorUser.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerConductorUser.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerCorrelationIdsSearchRequest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerCorrelationIdsSearchRequest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerCreateAccessKeyResponse.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerCreateAccessKeyResponse.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerCreateOrUpdateApplicationRequest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerCreateOrUpdateApplicationRequest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerGenerateTokenRequest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerGenerateTokenRequest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerGrantedAccess.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerGrantedAccess.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerGrantedAccessResponse.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerGrantedAccessResponse.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerGroup.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerGroup.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerPermission.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerPermission.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerRole.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerRole.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerSaveScheduleRequest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerSaveScheduleRequest.java
@@ -18,7 +18,8 @@ import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,15 +28,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 //todo - adding Missing fields in classes of which this class is composed and it will pass this test
 class TestSerDerSaveScheduleRequest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                            .withVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE))
+            .build();
 
     @Test
     void testSerializeDeserialize() throws Exception {
         // 1. Unmarshal SERVER_JSON to SDK POJO
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("SaveScheduleRequest");
-        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        objectMapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
         SaveScheduleRequest saveScheduleRequest = objectMapper.readValue(SERVER_JSON, SaveScheduleRequest.class);
 
         // 2. Assert that the fields are all correctly populated

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerSubject.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerSubject.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerSubjectRef.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerSubjectRef.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerTargetRef.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerTargetRef.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerTaskDetails.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerTaskDetails.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerTerminateWorkflow.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerTerminateWorkflow.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerTokenResponse.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerTokenResponse.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerUpsertGroupRequest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerUpsertGroupRequest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import io.orkes.conductor.client.model.UpsertGroupRequest.RolesEnum;
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerUpsertUserRequest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerUpsertUserRequest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerWorkflowSchedule.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerWorkflowSchedule.java
@@ -18,8 +18,9 @@ import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,15 +28,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 //todo add missing fields should pass this test
 public class TestSerDerWorkflowSchedule {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                            .withVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE))
+            .build();
 
     @Test
     public void testSerializationDeserialization() throws Exception {
         // 1. Unmarshal SERVER_JSON to SDK POJO
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("WorkflowSchedule");
-        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        objectMapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
         WorkflowSchedule workflowSchedule = objectMapper.readValue(SERVER_JSON, WorkflowSchedule.class);
 
         // 2. Assert that the fields are all correctly populated

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerWorkflowScheduleExecutionModel.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerWorkflowScheduleExecutionModel.java
@@ -20,7 +20,8 @@ import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -28,15 +29,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 //todo - adding Missing fields in classes of which this class is composed and it will pass this test
 public class TestSerDerWorkflowScheduleExecutionModel {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .changeDefaultVisibility(
+                    vc ->
+                            vc
+                            .withVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                            .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                            .withVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE))
+            .build();
 
     @Test
     public void testSerializationDeserialization() throws Exception {
         // 1. Unmarshal SERVER_JSON to SDK POJO
         String SERVER_JSON = JsonTemplateSerDeserResolverUtil.getJsonString("WorkflowScheduleExecutionModel");
-        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        objectMapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
         WorkflowScheduleExecutionModel model = objectMapper.readValue(SERVER_JSON, WorkflowScheduleExecutionModel.class);
 
         // 2. Assert that the fields are all correctly populated

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerWorkflowStateUpdate.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerWorkflowStateUpdate.java
@@ -20,7 +20,7 @@ import com.netflix.conductor.common.metadata.tasks.TaskResult;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerWorkflowStatus.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/TestSerDerWorkflowStatus.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/agent/AgentModelJsonTest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/agent/AgentModelJsonTest.java
@@ -17,8 +17,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDePromptTemplateTestRequest.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDePromptTemplateTestRequest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegration.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegration.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import io.orkes.conductor.client.model.TagObject;
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegrationApi.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegrationApi.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import io.orkes.conductor.client.model.TagObject;
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegrationApiUpdate.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegrationApiUpdate.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegrationDef.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegrationDef.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegrationUpdate.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/model/integration/TestSerDerIntegrationUpdate.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/io/orkes/conductor/client/util/JsonTemplateSerDeserResolverUtil.java
+++ b/conductor-client/src/test/java/io/orkes/conductor/client/util/JsonTemplateSerDeserResolverUtil.java
@@ -18,10 +18,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Utility class for resolving JSON templates from a predefined resource file.
@@ -112,7 +112,7 @@ public class JsonTemplateSerDeserResolverUtil {
         }
 
         // Create a deep copy of the content node
-        ObjectNode resultNode = contentNode.deepCopy();
+        ObjectNode resultNode = (ObjectNode) contentNode.deepCopy();
 
         // Process inheritance if present
         JsonNode inheritsNode = template.get("inherits");
@@ -139,7 +139,7 @@ public class JsonTemplateSerDeserResolverUtil {
      */
     private static void mergeNodes(ObjectNode target, JsonNode source) {
         if (source.isObject()) {
-            Iterator<String> fieldNames = source.fieldNames();
+            Iterator<String> fieldNames = source.propertyNames().iterator();
             while (fieldNames.hasNext()) {
                 String fieldName = fieldNames.next();
                 JsonNode sourceValue = source.get(fieldName);
@@ -173,7 +173,7 @@ public class JsonTemplateSerDeserResolverUtil {
      * Resolves references in an object node.
      */
     private static void resolveObjectReferences(ObjectNode objectNode, Set<String> processedDependencies) throws IOException {
-        Iterator<String> fieldNames = objectNode.fieldNames();
+        Iterator<String> fieldNames = objectNode.propertyNames().iterator();
         Set<String> fieldsToProcess = new HashSet<>();
 
         // Collect field names to avoid ConcurrentModificationException
@@ -203,7 +203,7 @@ public class JsonTemplateSerDeserResolverUtil {
                 JsonNode resolvedReference = resolveTemplateWithInheritance(referenceName, new HashSet<>());
 
                 // Only apply if the resolved reference is a simple value (string, number, etc.)
-                if (!resolvedReference.isContainerNode()) {
+                if (!resolvedReference.isContainer()) {
                     String resolvedKey = resolvedReference.asText();
 
                     // Remove the original reference key and add the resolved key with the same value

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerChatCompletion.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerChatCompletion.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerChatMessage.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerChatMessage.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerEmbeddingGenRequest.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerEmbeddingGenRequest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerIndexDocInput.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerIndexDocInput.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerIndexedDoc.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerIndexedDoc.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerLLMResponse.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerLLMResponse.java
@@ -17,15 +17,17 @@ import org.junit.jupiter.api.Test;
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestSerDerLLMResponse {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final ObjectMapper nonNullMapper = new ObjectMapper()
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    private final ObjectMapper nonNullMapper = JsonMapper.builder()
+            .changeDefaultPropertyInclusion(incl -> JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+            .build();
 
     @Test
     public void testSerializationDeserialization() throws Exception {

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerLLMWorkerInput.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerLLMWorkerInput.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerPromptTemplateTestRequest.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerPromptTemplateTestRequest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerStoreEmbeddingsInput.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerStoreEmbeddingsInput.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerTextCompletion.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerTextCompletion.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerVectorDBInput.java
+++ b/conductor-client/src/test/java/org/conductoross/conductor/client/model/ai/TestSerDerVectorDBInput.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import io.orkes.conductor.client.util.JsonTemplateSerDeserResolverUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/e2e/src/test/java/BaseTest.java
+++ b/e2e/src/test/java/BaseTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeAll;
 
 import io.orkes.conductor.client.model.agent.CompileResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;

--- a/e2e/src/test/java/PlanExecuteTest.java
+++ b/e2e/src/test/java/PlanExecuteTest.java
@@ -197,8 +197,8 @@ class PlanExecuteTest extends BaseTest {
 
                     List<String> paths;
                     try {
-                        com.fasterxml.jackson.databind.ObjectMapper mapper =
-                                new com.fasterxml.jackson.databind.ObjectMapper();
+                        tools.jackson.databind.ObjectMapper mapper =
+                                new tools.jackson.databind.ObjectMapper();
                         paths = mapper.readValue(
                                 inputPathsJson,
                                 mapper.getTypeFactory().constructCollectionType(List.class, String.class));
@@ -826,7 +826,7 @@ class PlanExecuteTest extends BaseTest {
             java.net.http.HttpResponse<String> resp =
                     http.send(req, java.net.http.HttpResponse.BodyHandlers.ofString());
             if (resp.statusCode() >= 400) return null;
-            return new com.fasterxml.jackson.databind.ObjectMapper().readValue(resp.body(), Map.class);
+            return new tools.jackson.databind.ObjectMapper().readValue(resp.body(), Map.class);
         } catch (Exception e) {
             return null;
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.1.0-SNAPSHOT
+version=7.0.0-SNAPSHOT

--- a/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
+++ b/tests/src/test/java/io/orkes/conductor/client/http/TaskClientTests.java
@@ -49,7 +49,7 @@ import com.netflix.conductor.sdk.workflow.executor.WorkflowExecutor;
 import io.orkes.conductor.client.util.ClientTestUtil;
 import io.orkes.conductor.client.util.TestUtil;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
+++ b/tests/src/test/java/io/orkes/conductor/client/util/TestUtil.java
@@ -25,7 +25,7 @@ import com.netflix.conductor.common.run.Workflow;
 
 import io.orkes.conductor.client.http.OrkesWorkflowClient;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.awaitility.Awaitility.await;
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -2,7 +2,10 @@ ext {
     versions = [
             okHttp        : '4.12.0',
             guava         : '33.6.0-jre',
-            jackson       : '2.18.6',
+            // Jackson 3 (tools.jackson.*). Aligned with the Spring Boot 4.1.1 BOM's jackson-bom.
+            jackson       : '3.1.5',
+            // Jackson 3 keeps annotations on the com.fasterxml.jackson 2.x line.
+            jacksonAnnotations: '2.21',
             archaius      : '0.7.12',
             slf4j         : '1.7.36',
             log4j         : '2.25.4',


### PR DESCRIPTION
Migrates the SDK to Jackson 3 (tools.jackson 3.1.5) and bumps the spring-boot4 module to Boot 4.1.1. ObjectMapperProvider keeps signature and wire-format parity with org.conductoross:conductor-common:4.0.0-alpha.1 (built from conductor-oss/conductor branch feat/spring-boot-4-upgrade) so both jars are interchangeable on a shared classpath. All 1349 unit tests pass. Targets release 7.0.0-alpha.1.